### PR TITLE
Added ability for upstream proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ _Default: RFC 2616 compliant_
 
 - **upstream_servers [URL(s)]**
 Sets a collection (space delimited) of upstream proxy servers to forward traffic.  Basic proxy authentication is supported, and should be included in the URL as shown in the example.  Traffic is load balanced using source IP Hash.
-_Default: no upstream servers, traffic will be pulled directly by the proxy server.
+_Default: no upstream servers, traffic will be pulled directly by the proxy server._
 
 
 ## Client Configuration

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ forwardproxy {
     serve_pac        /secret-proxy.pac
     response_timeout 30
     dial_timeout     30
+    disable_via
+    upstream_servers http://user:password@proxy1:3128 http://user:pass@proxy2:8080
 }
 ```
 
@@ -50,6 +52,14 @@ _Default: no timeout (other timeouts will eventually close the connection)._
 - **dial_timeout [integer]**  
 Sets timeout (in seconds) for establishing TCP connection to target website. Affects all requests.  
 _Default: 20 seconds._
+
+- **disable_via**
+If set, disable adding the Via header to traffic coming through the proxy.  This breaks compliance with RFC 2616, but does add a level anonimity to traffic through the proxy.
+_Default: RFC 2616 compliant_
+
+- **upstream_servers [URL(s)]**
+Sets a collection (space delimited) of upstream proxy servers to forward traffic.  Basic proxy authentication is supported, and should be included in the URL as shown in the example.  Traffic is load balanced using source IP Hash.
+_Default: no upstream servers, traffic will be pulled directly by the proxy server.
 
 
 ## Client Configuration

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -279,15 +279,12 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 				return http.StatusBadRequest, err
 			}
 
-			fmt.Println("Inside upstream")
 			var proxySRV = SelectUpstreamProxy(fp, r)
-			fmt.Println("Parsing proxy url")
+
 			proxyURL, err := url.Parse(proxySRV.Address)
 			if err != nil {
-				fmt.Printf("Response failed: %s\n", strconv.Itoa(http.StatusInternalServerError))
 				return http.StatusInternalServerError, errors.New("Bad Upstream Config")
 			}
-			fmt.Println("Changing headers")
 			if len(proxySRV.UserName) > 0 {
 				auth := fmt.Sprintf(proxySRV.UserName + ":" + proxySRV.Password)
 				basic := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
@@ -295,7 +292,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 				outReq.Header.Add("Proxy-Authorization", basic)
 				r.Header.Del("Proxy-Authorization")
 				r.Header.Add("Proxy-Authorization", basic)
-				fmt.Println("Headers adjusted")
+
 			}
 			var withBasicProxyAuth = http_dialer.WithProxyAuth(http_dialer.AuthBasic(proxySRV.UserName, proxySRV.Password))
 			var withConnectionTimeout = http_dialer.WithConnectionTimeout(fp.dialTimeout)
@@ -321,25 +318,6 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 			default:
 				panic("There was a check for http version, yet it's incorrect")
 			}
-			//fmt.Println("Setting TLS Info")
-			//fp.httpTransport.TLSClientConfig = &tls.Config{}
-			/*fp.httpTransport.Proxy = http.ProxyURL(proxyURL)
-			fmt.Println("Sending request")
-			response, err := fp.httpTransport.RoundTrip(outReq)
-			if err != nil {
-				if response != nil {
-					if response.StatusCode != 0 {
-						fmt.Printf("Response failed: %s\n", strconv.Itoa(response.StatusCode))
-						return response.StatusCode, errors.New("failed to do RoundTrip(): " + err.Error())
-
-					}
-				}
-				fmt.Printf("Response failed: %s\n", strconv.Itoa(http.StatusBadGateway))
-				return http.StatusBadGateway, errors.New("failed to do RoundTrip(): " + err.Error())
-
-			}
-			fmt.Println("Forwarding response")
-			return 0, forwardResponse(w, response, fp.disableVIA)*/
 		} else {
 		}
 		targetConn, err := net.DialTimeout("tcp", r.URL.Hostname()+":"+r.URL.Port(), fp.dialTimeout)
@@ -449,11 +427,9 @@ func forwardResponse(w http.ResponseWriter, response *http.Response, bvia bool) 
 
 		removeHopByHop(w.Header())
 	} else {
-		fmt.Printf("Inside forward response Method: %s\n", response.Request.Method)
 		for header, values := range response.Header {
 			for _, val := range values {
 				w.Header().Add(header, val)
-				fmt.Printf("Header: %s : %v\n", header, val)
 			}
 		}
 

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -273,11 +273,11 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 			return http.StatusForbidden, errors.New("CONNECT port not allowed for " + r.URL.String())
 		}
 		if len(fp.upstreamServers) != 0 {
-			/*outReq, err := fp.generateForwardRequest(r)
+			outReq, err := fp.generateForwardRequest(r)
 			if err != nil {
 				return http.StatusBadRequest, err
 			}
-			*/
+
 			fmt.Println("Inside upstream")
 			var proxySRV = SelectUpstreamProxy(fp, r)
 			fmt.Println("Parsing proxy url")
@@ -291,7 +291,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 				auth := fmt.Sprintf(proxySRV.UserName + ":" + proxySRV.Password)
 				basic := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
 				//fp.httpTransport.ProxyConnectHeader.Add("Proxy-Authorization", basic)
-				//outReq.Header.Add("Proxy-Authorization", basic)
+				outReq.Header.Add("Proxy-Authorization", basic)
 				r.Header.Del("Proxy-Authorization")
 				r.Header.Add("Proxy-Authorization", basic)
 				fmt.Println("Headers adjusted")
@@ -300,7 +300,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 			fp.httpTransport.TLSClientConfig = &tls.Config{}
 			fp.httpTransport.Proxy = http.ProxyURL(proxyURL)
 			fmt.Println("Sending request")
-			response, err := fp.httpTransport.RoundTrip(r)
+			response, err := fp.httpTransport.RoundTrip(outReq)
 			if err != nil {
 				if response != nil {
 					if response.StatusCode != 0 {

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jeddytier4/go-http-dialer"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
@@ -272,6 +273,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 			return http.StatusForbidden, errors.New("CONNECT port not allowed for " + r.URL.String())
 		}
 		if len(fp.upstreamServers) != 0 {
+
 			outReq, err := fp.generateForwardRequest(r)
 			if err != nil {
 				return http.StatusBadRequest, err
@@ -295,9 +297,33 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 				r.Header.Add("Proxy-Authorization", basic)
 				fmt.Println("Headers adjusted")
 			}
+			var withBasicProxyAuth = http_dialer.WithProxyAuth(http_dialer.AuthBasic(proxySRV.UserName, proxySRV.Password))
+			var withConnectionTimeout = http_dialer.WithConnectionTimeout(fp.dialTimeout)
+			dialer := http_dialer.New(proxyURL, withBasicProxyAuth, withConnectionTimeout)
+			targetConn, err := dialer.Dial("tcp", r.URL.Hostname()+":"+r.URL.Port())
+			if err != nil {
+				return http.StatusBadGateway, errors.New(fmt.Sprintf("Dial %s failed: %v", r.URL.String(), err))
+			}
+			defer targetConn.Close()
+
+			switch r.ProtoMajor {
+			case 1: // http1: hijack the whole flow
+				return serveHijack(w, targetConn)
+			case 2: // http2: keep reading from "request" and writing into same response
+				defer r.Body.Close()
+				wFlusher, ok := w.(http.Flusher)
+				if !ok {
+					return http.StatusInternalServerError, errors.New("ResponseWriter doesn't implement Flusher()")
+				}
+				w.WriteHeader(http.StatusOK)
+				wFlusher.Flush()
+				return 0, dualStream(targetConn, r.Body, w, targetConn)
+			default:
+				panic("There was a check for http version, yet it's incorrect")
+			}
 			//fmt.Println("Setting TLS Info")
 			//fp.httpTransport.TLSClientConfig = &tls.Config{}
-			fp.httpTransport.Proxy = http.ProxyURL(proxyURL)
+			/*fp.httpTransport.Proxy = http.ProxyURL(proxyURL)
 			fmt.Println("Sending request")
 			response, err := fp.httpTransport.RoundTrip(outReq)
 			if err != nil {
@@ -313,7 +339,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 
 			}
 			fmt.Println("Forwarding response")
-			return 0, forwardResponse(w, response, fp.disableVIA)
+			return 0, forwardResponse(w, response, fp.disableVIA)*/
 		} else {
 		}
 		targetConn, err := net.DialTimeout("tcp", r.URL.Hostname()+":"+r.URL.Port(), fp.dialTimeout)

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -407,6 +407,7 @@ func IPHash(pool []UpStreamProxy, request *http.Request) *UpStreamProxy {
 	if err != nil {
 		clientIP = request.RemoteAddr
 	}
+	fmt.Printf("Client IP: %s\n", clientIP)
 	return hostByHashing(pool, clientIP)
 }
 

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -18,6 +18,7 @@ package forwardproxy
 
 import (
 	"crypto/subtle"
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -285,6 +286,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 				fmt.Printf("Response failed: %s\n", strconv.Itoa(http.StatusInternalServerError))
 				return http.StatusInternalServerError, errors.New("Bad Upstream Config")
 			}
+			fmt.Println("Changing headers")
 			if len(proxySRV.UserName) > 0 {
 				auth := fmt.Sprintf(proxySRV.UserName + ":" + proxySRV.Password)
 				basic := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
@@ -294,6 +296,8 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 				r.Header.Add("Proxy-Authorization", basic)
 				fmt.Println("Headers adjusted")
 			}
+			fmt.Println("Setting TLS Info")
+			fp.httpTransport.TLSClientConfig = &tls.Config{}
 			fp.httpTransport.Proxy = http.ProxyURL(proxyURL)
 			fmt.Println("Sending request")
 			response, err := fp.httpTransport.RoundTrip(r)

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -286,6 +286,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 				auth := fmt.Sprintf(proxySRV.UserName + ":" + proxySRV.Password)
 				basic := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
 				fp.httpTransport.ProxyConnectHeader.Add("Proxy-Authorization", basic)
+				outReq.Header.Add("Proxy-Authorization", basic)
 			}
 			fp.httpTransport.Proxy = http.ProxyURL(proxyURL)
 			response, err := fp.httpTransport.RoundTrip(outReq)

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -274,10 +274,10 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 		}
 		if len(fp.upstreamServers) != 0 {
 
-			outReq, err := fp.generateForwardRequest(r)
-			if err != nil {
-				return http.StatusBadRequest, err
-			}
+			//outReq, err := fp.generateForwardRequest(r)
+			//if err != nil {
+			//	return http.StatusBadRequest, err
+			//}
 
 			var proxySRV = SelectUpstreamProxy(fp, r)
 
@@ -289,7 +289,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 				auth := fmt.Sprintf(proxySRV.UserName + ":" + proxySRV.Password)
 				basic := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
 				//fp.httpTransport.ProxyConnectHeader.Add("Proxy-Authorization", basic)
-				outReq.Header.Add("Proxy-Authorization", basic)
+				//outReq.Header.Add("Proxy-Authorization", basic)
 				r.Header.Del("Proxy-Authorization")
 				r.Header.Add("Proxy-Authorization", basic)
 

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -291,8 +291,10 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 				//outReq.Header.Add("Proxy-Authorization", basic)
 				r.Header.Del("Proxy-Authorization")
 				r.Header.Add("Proxy-Authorization", basic)
+				fmt.Println("Headers adjusted")
 			}
 			fp.httpTransport.Proxy = http.ProxyURL(proxyURL)
+			fmt.Println("Sending request")
 			response, err := fp.httpTransport.RoundTrip(r)
 			if err != nil {
 				if response != nil {

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -272,24 +272,28 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 			return http.StatusForbidden, errors.New("CONNECT port not allowed for " + r.URL.String())
 		}
 		if len(fp.upstreamServers) != 0 {
-			outReq, err := fp.generateForwardRequest(r)
+			/*outReq, err := fp.generateForwardRequest(r)
 			if err != nil {
 				return http.StatusBadRequest, err
 			}
+			*/
 			fmt.Println("Inside upstream")
 			var proxySRV = SelectUpstreamProxy(fp, r)
 			proxyURL, err := url.Parse(proxySRV.Address)
 			if err != nil {
+				fmt.Printf("Response failed: %s\n", strconv.Itoa(http.StatusInternalServerError))
 				return http.StatusInternalServerError, errors.New("Bad Upstream Config")
 			}
 			if len(proxySRV.UserName) > 0 {
 				auth := fmt.Sprintf(proxySRV.UserName + ":" + proxySRV.Password)
 				basic := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
 				fp.httpTransport.ProxyConnectHeader.Add("Proxy-Authorization", basic)
-				outReq.Header.Add("Proxy-Authorization", basic)
+				//outReq.Header.Add("Proxy-Authorization", basic)
+				r.Header.Del("Proxy-Authorization")
+				r.Header.Add("Proxy-Authorization", basic)
 			}
 			fp.httpTransport.Proxy = http.ProxyURL(proxyURL)
-			response, err := fp.httpTransport.RoundTrip(outReq)
+			response, err := fp.httpTransport.RoundTrip(r)
 			if err != nil {
 				if response != nil {
 					if response.StatusCode != 0 {

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -290,7 +290,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 			if len(proxySRV.UserName) > 0 {
 				auth := fmt.Sprintf(proxySRV.UserName + ":" + proxySRV.Password)
 				basic := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
-				fp.httpTransport.ProxyConnectHeader.Add("Proxy-Authorization", basic)
+				//fp.httpTransport.ProxyConnectHeader.Add("Proxy-Authorization", basic)
 				//outReq.Header.Add("Proxy-Authorization", basic)
 				r.Header.Del("Proxy-Authorization")
 				r.Header.Add("Proxy-Authorization", basic)

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -279,6 +279,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 			*/
 			fmt.Println("Inside upstream")
 			var proxySRV = SelectUpstreamProxy(fp, r)
+			fmt.Println("Parsing proxy url")
 			proxyURL, err := url.Parse(proxySRV.Address)
 			if err != nil {
 				fmt.Printf("Response failed: %s\n", strconv.Itoa(http.StatusInternalServerError))

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -18,7 +18,6 @@ package forwardproxy
 
 import (
 	"crypto/subtle"
-	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -296,8 +295,8 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 				r.Header.Add("Proxy-Authorization", basic)
 				fmt.Println("Headers adjusted")
 			}
-			fmt.Println("Setting TLS Info")
-			fp.httpTransport.TLSClientConfig = &tls.Config{}
+			//fmt.Println("Setting TLS Info")
+			//fp.httpTransport.TLSClientConfig = &tls.Config{}
 			fp.httpTransport.Proxy = http.ProxyURL(proxyURL)
 			fmt.Println("Sending request")
 			response, err := fp.httpTransport.RoundTrip(outReq)

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -395,13 +395,17 @@ func forwardResponse(w http.ResponseWriter, response *http.Response, bvia bool) 
 	if !bvia {
 		w.Header().Add("Via", strconv.Itoa(response.ProtoMajor)+"."+strconv.Itoa(response.ProtoMinor)+" caddy")
 	}
-
+	fmt.Printf("Inside forward response Method: %s\n", response.Request.Method)
 	for header, values := range response.Header {
 		for _, val := range values {
 			w.Header().Add(header, val)
+			fmt.Printf("Header: %s : %v\n", header, val)
 		}
 	}
-	removeHopByHop(w.Header())
+	if response.Request.Method != http.MethodConnect {
+
+		removeHopByHop(w.Header())
+	}
 	w.WriteHeader(response.StatusCode)
 	buf := bufferPool.Get().([]byte)
 	buf = buf[0:cap(buf)]

--- a/setup.go
+++ b/setup.go
@@ -125,7 +125,9 @@ func setup(c *caddy.Controller) error {
 					servers = append(servers, tmpproxy)
 				}
 			}
+
 			fp.upstreamServers = servers
+			log.Printf("Upstream Servers: %s\n", fp.upstreamServers)
 
 		case "probe_resistance":
 			if len(args) > 1 {


### PR DESCRIPTION
Can use upstream proxies for http and connect, including proxies with authentication.  New to golang, so any comments are appreciated.  Added a configuration line to allow removal of the Via header, referenced in issue #8 .