### PR TITLE
 Reuse the original request, avoid the abnormal ContentLength

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -334,7 +334,7 @@ func (fp *ForwardProxy) decorateOriginalRequest(req *http.Request) (*http.Reques
 	if strUrl[0] == '/' {
 		strUrl = req.Host + strUrl
 	}
-	if !strings.Contains(strUrl, "://") {
+	if !strings.HasPrefix(strUrl, "http://") {
 		strUrl = "http://" + strUrl
 	}
 
@@ -343,6 +343,7 @@ func (fp *ForwardProxy) decorateOriginalRequest(req *http.Request) (*http.Reques
 		return nil, errors.New("malformed request: malformed URI")
 	}
 	req.URL = Url
+	req.RequestURI = ""
 
 	removeHopByHop(req.Header)
 

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -327,22 +326,12 @@ func (fp *ForwardProxy) decorateOriginalRequest(req *http.Request) (*http.Reques
 	// Scheme has to be appended to avoid `unsupported protocol scheme ""` error.
 	// `http://` is used, since this initial request itself is always HTTP, regardless of what client and server
 	// may speak afterwards.
-	if len(req.RequestURI) == 0 {
-		return nil, errors.New("malformed request: empty URI")
+	if req.URL.Scheme == "" {
+		req.URL.Scheme = "http"
 	}
-	strUrl := req.RequestURI
-	if strUrl[0] == '/' {
-		strUrl = req.Host + strUrl
+	if req.URL.Host == "" {
+		req.URL.Host = req.Host
 	}
-	if !strings.HasPrefix(strUrl, "http://") {
-		strUrl = "http://" + strUrl
-	}
-
-	Url, err := url.Parse(strUrl)
-	if err != nil {
-		return nil, errors.New("malformed request: malformed URI")
-	}
-	req.URL = Url
 	req.RequestURI = ""
 
 	removeHopByHop(req.Header)


### PR DESCRIPTION
The `http.NewRequest` did not set the right `ContentLength` due to the type of `inReq.Body`.
We need to change the input of `http.NewRequest` to `*bytes.Buffer`, `*bytes.Reader` or `*strings.Reader`.

BTW, we can just set `ContentLength` like this `outReq.ContentLength = inReq.ContentLength` to workaround.