### PR TITLE
Add Passthrough directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ _Default: no timeout (other timeouts will eventually close the connection)._
 Sets timeout (in seconds) for establishing TCP connection to target website. Affects all requests.  
 _Default: 20 seconds._
 
+- **passthrough**  
+UNTESTED. If set, forwardproxy will not forward requests, rather just pass them further down
+middleware chain. Example of usage: setting up non-forward
+[`proxy`](https://caddyserver.com/docs/proxy) that is protected by `forwardproxy` probe resistance.  
+_Default: forwardproxy will forward requests._
 
 ## Client Configuration
 

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -190,6 +190,7 @@ func serveHiddenPage(w http.ResponseWriter, authErr error) (int, error) {
 	const AuthFail = "Please authenticate yourself to the proxy."
 	const AuthOk = "Congratulations, you are successfully authenticated to the proxy! Go browse all the things!"
 
+	w.Header().Set("Content-Type", "text/html")
 	if authErr != nil {
 		w.Header().Set("Proxy-Authenticate", "Basic")
 		w.WriteHeader(http.StatusProxyAuthRequired)

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -38,6 +38,7 @@ type ForwardProxy struct {
 	authCredentials    [][]byte // slice with base64-encoded credentials
 	hideIP             bool
 	hideVia            bool
+	passthrough        bool // do not proxy requests, just push them down middleware chain
 	whitelistedPorts   []int
 	probeResistDomain  string
 	pacFilePath        string
@@ -246,6 +247,10 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 			w.Header().Set("Proxy-Authenticate", "Basic")
 			return http.StatusProxyAuthRequired, authErr
 		}
+	}
+
+	if fp.passthrough {
+		return fp.Next.ServeHTTP(w, r)
 	}
 
 	if r.ProtoMajor != 1 && r.ProtoMajor != 2 {

--- a/setup.go
+++ b/setup.go
@@ -94,6 +94,11 @@ func setup(c *caddy.Controller) error {
 				return c.ArgErr()
 			}
 			fp.hideIP = true
+		case "passthrough":
+			if len(args) != 0 {
+				return c.ArgErr()
+			}
+			fp.passthrough = true
 		case "hide_via":
 			if len(args) != 0 {
 				return c.ArgErr()

--- a/setup_test.go
+++ b/setup_test.go
@@ -84,6 +84,10 @@ func TestSetup(t *testing.T) {
 	testParsing([]string{"hide_ip 0"}, false)
 	testParsing([]string{"hide_ip 0 1"}, false)
 
+	testParsing([]string{"passthrough"}, true)
+	testParsing([]string{"passthrough 0"}, false)
+	testParsing([]string{"passthrough 0 1"}, false)
+
 	testParsing([]string{"hide_via"}, true)
 	testParsing([]string{"hide_via 0"}, false)
 	testParsing([]string{"hide_via 0 1"}, false)


### PR DESCRIPTION
UNTESTED. If set, forwardproxy will not forward requests, rather just pass them
further down middleware chain.
Implements #17 