### PR TITLE
Add upstream proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Open a block for more control; here's an example of all properties in use (note 
 ```
 forwardproxy {
     basicauth user1 0NtCL2JPJBgPPMmlPcJ
-    basicauth user2 秘密
+    basicauth user2 密码
     ports     80 443
     hide_ip
     probe_resistance secretlink.localhost
@@ -59,6 +59,9 @@ _Default: no timeout (other timeouts will eventually close the connection)._
 Sets timeout (in seconds) for establishing TCP connection to target website. Affects all requests.  
 _Default: 20 seconds._
 
+- **upstream [https://username:password@proxy.site]**
+Sets upstream proxy for establishing TCP connection to target website. Affects all requests.
+_Default: no upstream proxy._
 
 ## Client Configuration
 

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -45,8 +45,9 @@ type ForwardProxy struct {
 	dialTimeout        time.Duration // for initial tcp connection
 	hostname           string        // do not intercept requests to the hostname (except for hidden link)
 	port               string        // port on which chain with forwardproxy is listening on
-	upstream           string
-	dial               func(network, address string) (net.Conn, error)
+
+	upstream string                                          // upstream store the upstream server addr
+	dial     func(network, address string) (net.Conn, error) // when upstream is not empty, should customize dial function
 }
 
 var bufferPool sync.Pool

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -45,6 +45,8 @@ type ForwardProxy struct {
 	dialTimeout        time.Duration // for initial tcp connection
 	hostname           string        // do not intercept requests to the hostname (except for hidden link)
 	port               string        // port on which chain with forwardproxy is listening on
+	upstream           string
+	dial               func(network, address string) (net.Conn, error)
 }
 
 var bufferPool sync.Pool
@@ -263,7 +265,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 			return http.StatusForbidden, errors.New("CONNECT port not allowed for " + r.URL.String())
 		}
 
-		targetConn, err := net.DialTimeout("tcp", r.URL.Hostname()+":"+r.URL.Port(), fp.dialTimeout)
+		targetConn, err := fp.dial("tcp", r.URL.Hostname()+":"+r.URL.Port())
 		if err != nil {
 			return http.StatusBadGateway, errors.New(fmt.Sprintf("Dial %s failed: %v", r.URL.String(), err))
 		}

--- a/setup.go
+++ b/setup.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
-	"github.com/yaproxy/libyap/proxy"
+	"golang.org/x/net/proxy"
 )
 
 func setup(c *caddy.Controller) error {
@@ -188,7 +188,7 @@ func setup(c *caddy.Controller) error {
 				KeepAlive: 30 * time.Second,
 				DualStack: true,
 			}
-			newDialer, err := proxy.FromURL(fixedURL, dialer, nil)
+			newDialer, err := proxy.FromURL(fixedURL, dialer)
 			if err != nil {
 				return errors.New("wrong upstream address")
 			}

--- a/setup_test.go
+++ b/setup_test.go
@@ -111,4 +111,8 @@ func TestSetup(t *testing.T) {
 	testParsing([]string{"dial_timeout 1 2"}, false)
 	testParsing([]string{"dial_timeout seven"}, false)
 	testParsing([]string{"dial_timeout 2"}, true)
+
+	testParsing([]string{"upstream proxy.site"}, false)
+	testParsing([]string{"upstream https://proxy.site https://proxy.site"}, false)
+	testParsing([]string{"upstream https://proxy.site"}, true)
 }


### PR DESCRIPTION
Proxy chains is useful for some scenario when the network is protected by some gateway.

This PR adds a option named `upstream` like:

```
forwardproxy {
    upstream https://upstearm.proxy.site
}
```

The upstream proxy supports multiple types proxy, like `https://a.com`, `http://b.com`, `sock5://c.com`, `http2://d.com`, for this we import a sub library `proxy` in `github.com/yaproxy/libyap`

And I don't know how caddy deals with dependency.
The official tool `dep` is good enough to do this.

**TODO**:

* multi upstream support ?
* customize DNS resolver ?