### PR TITLE
Add Access Control Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Secure forward proxy plugin for the Caddy web server
 
-[![Build Status](https://travis-ci.org/refraction-networking/utls.svg?branch=master)](https://travis-ci.org/refraction-networking/utls)
+[![Build Status](https://travis-ci.org/caddyserver/forwardproxy.svg?branch=master)](https://travis-ci.org/caddyserver/forwardproxy)
 
 This plugin enables [Caddy](https://caddyserver.com) to act as a forward proxy (as opposed to reverse proxy, Caddy's standard `proxy` directive) for HTTP/2.0 and HTTP/1.1 requests (HTTP/1.0 might work, but is untested).
 
@@ -22,18 +22,41 @@ forwardproxy {
     response_timeout 30
     dial_timeout     30
     upstream         https://user:password@extra-upstream-hop.com
+    acl {
+      allow     *.caddyserver.com
+      deny      192.168.1.1/32 192.168.0.0/16 *.prohibitedsite.com *.localhost
+      allow     ::1/128 8.8.8.8 github.com *.github.io
+      allowfile /path/to/whitelist.txt
+      denyfile  /path/to/blacklist.txt
+      allow     all
+      deny      all // unreachable rule, remaining requests are matched by `allow all`
+    }
 }
 ```
 
 (The square brackets `[ ]` indicate values you should replace; do not actually include the brackets.)
 
+##### Security
+
 - **basicauth [user] [password]**  
 Sets basic HTTP auth credentials. This property may be repeated multiple times. Note that this is different from Caddy's built-in `basicauth` directive. BE SURE TO CHECK THE NAME OF THE SITE THAT IS REQUESTING CREDENTIALS BEFORE YOU ENTER THEM.  
 _Default: no authentication required._
 
-- **ports [integer] [integer]...**  
-Whitelists ports forwardproxy will HTTP CONNECT to.  
-_Default: no restrictions._
+- **probe_resistance [secretlink.tld]**  
+Attempts to hide the fact that the site is a forward proxy.
+Proxy will no longer respond with "407 Proxy Authentication Required" if credentials are incorrect or absent,
+and will attempt to mimic a generic Caddy web server as if the forward proxy is not enabled.  
+Probing resistance works (and makes sense) only if basicauth is set up.
+To use your proxy with probe resistance, supply your basicauth credentials to your client configuration.
+If your proxy client(browser, operating system, [browser extension](https://chrome.google.com/webstore/detail/proxy-switchyomega/padekgcemlokbadohgkifijomclgjgif), etc.)
+allows you to preconfigure credentials, and sends credentials preemptively, you do not need secret link.  
+If your proxy client does not preemptively send credentials, you will have to visit your secret link in your browser to trigger the authentication.
+Make sure that specified domain name is visitable, does not contain uppercase characters, does not start with dot, etc.
+Only this address will trigger a 407 response, prompting browsers to request credentials from user and cache them for the rest of the session.
+It is possible to use any top level domain, but for secrecy reasons it is highly recommended to use `.localhost`.  
+_Default: no probing resistance._
+
+##### Privacy
 
 - **hide_ip**  
 If set, forwardproxy will not add user's IP to "Forwarded:" header.  
@@ -45,25 +68,66 @@ If set, forwardproxy will not add Via header, and prevents simple way to detect 
 WARNING: there are other side-channels to determine this.  
 _Default: no hiding; Header in form of `Via: 2.0 caddy` will be sent out._
 
-- **probe_resistance [secretlink.tld]**  
-EXPERIMENTAL. (Here be dragons!) Attempts to hide the fact that the site is a forward proxy. Proxy will no longer respond with "407 Proxy Authentication Required" if credentials are incorrect or absent, and will attempt to mimic a generic Caddy web server as if the forward proxy is not configured. Since not all clients (browsers, operating systems, etc.) are able to be configured to send credentials right away (some only authenticate after receiving a 407), we will use a secret link. Make sure that specified domain name is visitable, does not contain uppercase characters, does not start with dot, etc. Only this address will trigger a 407 response, prompting browsers to request credentials from users and cache them for the rest of the session. It is possible to use any top level domain (tld), but for secrecy reasons it is highly recommended to use `.localhost`. Probing resistance works (and makes sense) only if basicauth is set up. To use your proxy with probe resistance, supply your basicauth credentials to your client configuration if possible. If your proxy client does not authenticate right away, you may then have to visit your secret link in your browser to trigger the authentication.  
-_Default: no probing resistance._
+##### Access Control
 
-- **serve_pac [/path.pac]**  
-Generate (in-memory) and serve a [Proxy Auto-Config](https://en.wikipedia.org/wiki/Proxy_auto-config) file on given path. If no path is provided, the PAC file will be served at `/proxy.pac`. NOTE: If you enable probe_resistance, your PAC file should also be served at a secret location; serving it at a predictable path can easily defeat probe resistance.  
-_Default: no PAC file will be generated or served by Caddy (you still can manually create and serve proxy.pac like a regular file)._
+- **ports [integer] [integer]...**  
+Specifies ports forwardproxy will whitelist for all requests. Other ports will be forbidden.  
+_Default: no restrictions._
+
+- **acl {  
+&nbsp;&nbsp;&nbsp;&nbsp;acl_directive  
+&nbsp;&nbsp;&nbsp;&nbsp;...  
+&nbsp;&nbsp;&nbsp;&nbsp;acl_directive  
+}**  
+Specifies **order** and rules for allowed destination IP networks, IP addresses and hostnames.
+The hostname in each forwardproxy request will be resolved to an IP address,
+and caddy will check the IP address and hostname against the directives in order until a directive matches the request.
+acl_directive may be:
+  - **allow [ip or subnet or hostname] [ip or subnet or hostname]...**
+  - **allowfile /path/to/whitelist.txt**
+  - **deny [ip or subnet or hostname] [ip or subnet or hostname]...**
+  - **denyfile /path/to/blacklist.txt**
+
+  If you don't want unmatched requests to be subject to the default policy, you could finish
+  your acl rules with one of the following to specify action on unmatched requests:
+  - **allow all**
+  - **deny all**
+  
+  For hostname, you can specify `*.` as a prefix to match domain and subdomains. For example,
+  `*.caddyserver.com` will match caddyserver.com, subdomain.caddyserver.com, but not fakecaddyserver.com.
+  Note that hostname rule, matched early in the chain, will override later IP rules,
+  so it is advised to put IP rules first, unless domains are highly trusted and should override the
+  IP rules. Also note that domain-based blacklists are easily circumventable by directly specifying the IP.  
+  For `allowfile`/`denyfile` directives, syntax is the same, and each entry must be separated by newline.  
+  This policy applies to all requests except requests to the proxy's own domain and port.
+  Whitelisting/blacklisting of ports on per-host/IP basis is not supported.  
+_Default policy:_  
+acl {  
+&nbsp;&nbsp;&nbsp;&nbsp;deny 10.0.0.0/8 127.0.0.0/8 172.16.0.0/12 192.168.0.0/16 ::1/128 fe80::/10  
+&nbsp;&nbsp;&nbsp;&nbsp;allow all  
+}  
+_Default deny rules intend to prohibit access to localhost and local networks and may be expanded in future._
+
+##### Timeouts
 
 - **response_timeout [integer]**  
-Sets timeout (in seconds) for HTTP requests made by proxy on behalf of users (does not affect `CONNECT`-method requests).  
-_Default: no timeout (other timeouts will eventually close the connection)._
+Sets timeout (in seconds) to get full response for HTTP requests made by proxy on behalf of users (does not affect `CONNECT`-method requests).  
+_Default: no timeout._
 
 - **dial_timeout [integer]**  
 Sets timeout (in seconds) for establishing TCP connection to target website. Affects all requests.  
 _Default: 20 seconds._
 
+##### Other
+
+- **serve_pac [/path.pac]**  
+Generate (in-memory) and serve a [Proxy Auto-Config](https://en.wikipedia.org/wiki/Proxy_auto-config) file on given path. If no path is provided, the PAC file will be served at `/proxy.pac`. NOTE: If you enable probe_resistance, your PAC file should also be served at a secret location; serving it at a predictable path can easily defeat probe resistance.  
+_Default: no PAC file will be generated or served by Caddy (you still can manually create and serve proxy.pac like a regular file)._
+
 - **upstream [https://username:password@upstreamproxy.site:443]**  
 Sets upstream proxy to route all forwardproxy requests through it.
-This setting does not affect non-forwardproxy requests nor requests with wrong credentials.  
+This setting does not affect non-forwardproxy requests nor requests with wrong credentials.
+Upstream is incompatible with `acl` and `ports` subdirectives.  
 Supported schemes to remote host: https.  
 Supported schemes to localhost: socks5, http, https(certificate check is ignored).  
 _Default: no upstream proxy._

--- a/acl.go
+++ b/acl.go
@@ -1,0 +1,96 @@
+package forwardproxy
+
+import (
+	"errors"
+	"net"
+	"strings"
+)
+
+type aclDecision uint8
+
+const (
+	aclDecisionAllow = iota
+	aclDecisionDeny
+	aclDecisionNoMatch
+)
+
+type aclRule interface {
+	tryMatch(ip net.IP, domain string) aclDecision
+}
+
+type aclIPRule struct {
+	net   net.IPNet
+	allow bool
+}
+
+func (a *aclIPRule) tryMatch(ip net.IP, domain string) aclDecision {
+	if !a.net.Contains(ip) {
+		return aclDecisionNoMatch
+	}
+	if a.allow {
+		return aclDecisionAllow
+	}
+	return aclDecisionDeny
+
+}
+
+type aclDomainRule struct {
+	domain            string
+	subdomainsAllowed bool
+	allow             bool
+}
+
+func (a *aclDomainRule) tryMatch(ip net.IP, domain string) aclDecision {
+	if strings.HasSuffix(domain, ".") {
+		domain = domain[:len(domain)-1]
+	}
+	if domain == a.domain ||
+		a.subdomainsAllowed && strings.HasSuffix(domain, "."+a.domain) {
+		if a.allow {
+			return aclDecisionAllow
+		}
+		return aclDecisionDeny
+	}
+	return aclDecisionNoMatch
+}
+
+type aclAllRule struct {
+	allow bool
+}
+
+func (a *aclAllRule) tryMatch(ip net.IP, domain string) aclDecision {
+	if a.allow {
+		return aclDecisionAllow
+	}
+	return aclDecisionDeny
+}
+
+func newAclRule(ruleSubject string, allow bool) (aclRule, error) {
+	if ruleSubject == "all" {
+		return &aclAllRule{allow: allow}, nil
+	}
+	_, ipNet, err := net.ParseCIDR(ruleSubject)
+	if err != nil {
+		ip := net.ParseIP(ruleSubject)
+		// support specifying just an IP
+		if ip.To4() != nil {
+			_, ipNet, err = net.ParseCIDR(ruleSubject + "/32")
+		} else if ip.To16() != nil {
+			_, ipNet, err = net.ParseCIDR(ruleSubject + "/128")
+		}
+	}
+	if err == nil {
+		return &aclIPRule{net: *ipNet, allow: allow}, nil
+	}
+
+	subdomainsAllowed := false
+	if strings.HasPrefix(ruleSubject, `*.`) {
+		subdomainsAllowed = true
+		ruleSubject = ruleSubject[2:]
+	}
+	err = isValidDomainLite(ruleSubject)
+	if err != nil {
+		return nil, errors.New(ruleSubject + " could not be parsed as either IP, IP network, or domain: " + err.Error())
+	}
+	return &aclDomainRule{domain: ruleSubject, subdomainsAllowed: subdomainsAllowed, allow: allow}, nil
+}

--- a/acl_test.go
+++ b/acl_test.go
@@ -1,0 +1,199 @@
+package forwardproxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+/*
+test port blocking working
+test blacklist allowed
+test blacklist refused with correct status
+
+*/
+
+func TestWhitelistAllowing(t *testing.T) {
+	useTls := true
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy(caddyTestTarget.addr, resource, caddyForwardProxyWhiteListing.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if err = responseExpected(response, caddyTestTarget.contents[resource]); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+func TestWhitelistBlocking(t *testing.T) {
+	useTls := true
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy(caddyHTTPTestTarget.addr, resource, caddyForwardProxyWhiteListing.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy("google.com:6451", resource, caddyForwardProxyWhiteListing.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+}
+
+func TestLocalhostDefaultForbidden(t *testing.T) {
+	useTls := true
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy("localhost:6451", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy("127.0.0.1:808", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy("[::1]:8080", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+}
+
+func TestLocalNetworksDefaultForbidden(t *testing.T) {
+	useTls := true
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy("10.0.0.0:80", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy("127.222.34.1:443", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy("172.16.0.1:8080", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy("192.168.192.168:888", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+}
+
+func TestBlacklistBlocking(t *testing.T) {
+	useTls := true
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy(blacklistedDomain, resource, caddyForwardProxyBlackListing.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy(blacklistedIPv4, resource, caddyForwardProxyBlackListing.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy(blacklistedIPv6, resource, caddyForwardProxyBlackListing.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if response.StatusCode != http.StatusForbidden {
+				t.Fatal("Expected response \"403 Forbidden\", got:", response.StatusCode)
+			}
+		}
+	}
+}
+
+func TestBlacklistAllowing(t *testing.T) {
+	useTls := true
+	for _, httpTargetVer := range testHttpVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy(caddyTestTarget.addr, resource, caddyForwardProxyBlackListing.addr, httpTargetVer,
+				"", useTls)
+			if err != nil {
+				t.Fatal(err)
+			} else if err = responseExpected(response, caddyTestTarget.contents[resource]); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}

--- a/forwardproxy_test.go
+++ b/forwardproxy_test.go
@@ -61,7 +61,7 @@ func connectAndGetViaProxy(targetHost, resource, proxyAddr, httpTargetVer, proxy
 		connectRequest.Header.Set("Proxy-Authorization", proxyCredentials)
 	}
 	connectRequest.Host = targetHost
-	connectRequest.URL, err = url.Parse("http://" + connectRequest.Host)
+	connectRequest.URL, err = url.Parse("https://" + connectRequest.Host)
 	if err != nil {
 		return nil, err
 	}

--- a/setup_test.go
+++ b/setup_test.go
@@ -120,4 +120,18 @@ func TestSetup(t *testing.T) {
 	testParsing([]string{"upstream http://proxy.site"}, false)
 	testParsing([]string{"upstream https://proxy.site https://proxy.site"}, false)
 	testParsing([]string{"upstream https://proxy.site"}, true)
+	testParsing([]string{"upstream https://caddyserver.com", "acl {\nallow all\n}"}, false)
+	testParsing([]string{"upstream https://caddyserver.com", "ports 123"}, false)
+
+	testParsing([]string{"acl {\nallow all\n}"}, true)
+	testParsing([]string{"acl {\nallow localhost 128.32.22.1/32 1.1.1.1 caddyserver.com\n deny all\n}"}, true)
+	testParsing([]string{"acl {\nallowfile test/parseable_acl.txt\n}"}, true)
+	testParsing([]string{"acl {\ndenyfile test/parseable_acl.txt\n}"}, true)
+	testParsing([]string{"acl {\nallowfile test/unparseable_acl.txt\n}"}, false)
+	testParsing([]string{"acl {\ndenyfile test/unparseable_acl.txt\n}"}, false)
+	//testParsing([]string{"acl {\nallow all\n"}, false) // doesn't fail, but should: caddy itself doesn't demand curly brace to be closed
+	testParsing([]string{"acl {\nallow all\n", "serve_pac"}, false) // this does fail
+	testParsing([]string{"acl \nallow all\n}"}, false)
+	testParsing([]string{"acl {allow all\n}"}, false)
+	//testParsing([]string{"acl {\nallow all}"}, false) // '}' is not on the next line, "all}" parses as regexp
 }

--- a/test/parseable_acl.txt
+++ b/test/parseable_acl.txt
@@ -1,0 +1,6 @@
+128.12.2.3
+123.32.1.1/32
+qwe.com
+localhost
+lalalala
+usetor.usesignal

--- a/test/unparseable_acl.txt
+++ b/test/unparseable_acl.txt
@@ -1,0 +1,4 @@
+128.3.3.1/23
+previous.line.is.parseable.com
+but.next.line.is.not.parseable.com
+(za0zaz


### PR DESCRIPTION
### 1. What does this change do, exactly?
Adds access control lists to limit allowed destination domains and IP addresses. We settled on a powerful, but a bit complicated acl design.
We take advantage of ACL to add default blacklist, that prohibits access to localhost and local networks.
This PR removes http.Transport, which was previously used to dial and write http requests for insecure GET requests. Now we have to dial manually, so we can check the access control list.
Finally, this PR makes a couple of cosmetic improvements. 

### 2. Please link to the relevant issues.
#11 
#29 

### 3. Which documentation changes (if any) need to be made because of this PR?
Changes to readme were made.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
