### PR TITLE
Add timeout for streaming, fixes #33

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -109,12 +109,16 @@ func dualStream(w1 io.Writer, r1 io.Reader, w2 io.Writer, r2 io.Reader) error {
 
 	go stream(w1, r1)
 	go stream(w2, r2)
-	err1 := <-errChan
-	err2 := <-errChan
-	if err1 != nil {
-		return err1
+
+	firstHangerErr := <-errChan
+
+	closeTimeout := time.NewTimer(30 * time.Second)
+	select {
+	case _ = <-errChan:
+	case <-closeTimeout.C:
 	}
-	return err2
+	closeTimeout.Stop()
+	return firstHangerErr
 }
 
 // Hijacks the connection from ResponseWriter, writes the response and proxies data between targetConn


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Adds timeout to dualStream: now, when one side hangs up, we will read from the other one for 30 seconds, and close it.

### 2. Please link to the relevant issues.
Fixes #33

### 3. Which documentation changes (if any) need to be made because of this PR?
None

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
