### PR TITLE
Fix h2 tests

### DIFF
--- a/acl_test.go
+++ b/acl_test.go
@@ -14,9 +14,9 @@ test blacklist refused with correct status
 
 func TestWhitelistAllowing(t *testing.T) {
 	useTls := true
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy(caddyTestTarget.addr, resource, caddyForwardProxyWhiteListing.addr, httpTargetVer,
+			response, err := getViaProxy(caddyTestTarget.addr, resource, caddyForwardProxyWhiteListing.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -29,9 +29,9 @@ func TestWhitelistAllowing(t *testing.T) {
 
 func TestWhitelistBlocking(t *testing.T) {
 	useTls := true
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy(caddyHTTPTestTarget.addr, resource, caddyForwardProxyWhiteListing.addr, httpTargetVer,
+			response, err := getViaProxy(caddyHTTPTestTarget.addr, resource, caddyForwardProxyWhiteListing.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -41,9 +41,9 @@ func TestWhitelistBlocking(t *testing.T) {
 		}
 	}
 
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy("google.com:6451", resource, caddyForwardProxyWhiteListing.addr, httpTargetVer,
+			response, err := getViaProxy("google.com:6451", resource, caddyForwardProxyWhiteListing.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -56,9 +56,9 @@ func TestWhitelistBlocking(t *testing.T) {
 
 func TestLocalhostDefaultForbidden(t *testing.T) {
 	useTls := true
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy("localhost:6451", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+			response, err := getViaProxy("localhost:6451", resource, caddyForwardProxyNoBlacklistOverride.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -68,9 +68,9 @@ func TestLocalhostDefaultForbidden(t *testing.T) {
 		}
 	}
 
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy("127.0.0.1:808", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+			response, err := getViaProxy("127.0.0.1:808", resource, caddyForwardProxyNoBlacklistOverride.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -80,9 +80,9 @@ func TestLocalhostDefaultForbidden(t *testing.T) {
 		}
 	}
 
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy("[::1]:8080", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+			response, err := getViaProxy("[::1]:8080", resource, caddyForwardProxyNoBlacklistOverride.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -95,9 +95,9 @@ func TestLocalhostDefaultForbidden(t *testing.T) {
 
 func TestLocalNetworksDefaultForbidden(t *testing.T) {
 	useTls := true
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy("10.0.0.0:80", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+			response, err := getViaProxy("10.0.0.0:80", resource, caddyForwardProxyNoBlacklistOverride.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -107,9 +107,9 @@ func TestLocalNetworksDefaultForbidden(t *testing.T) {
 		}
 	}
 
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy("127.222.34.1:443", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+			response, err := getViaProxy("127.222.34.1:443", resource, caddyForwardProxyNoBlacklistOverride.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -119,9 +119,9 @@ func TestLocalNetworksDefaultForbidden(t *testing.T) {
 		}
 	}
 
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy("172.16.0.1:8080", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+			response, err := getViaProxy("172.16.0.1:8080", resource, caddyForwardProxyNoBlacklistOverride.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -131,9 +131,9 @@ func TestLocalNetworksDefaultForbidden(t *testing.T) {
 		}
 	}
 
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy("192.168.192.168:888", resource, caddyForwardProxyNoBlacklistOverride.addr, httpTargetVer,
+			response, err := getViaProxy("192.168.192.168:888", resource, caddyForwardProxyNoBlacklistOverride.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -146,9 +146,9 @@ func TestLocalNetworksDefaultForbidden(t *testing.T) {
 
 func TestBlacklistBlocking(t *testing.T) {
 	useTls := true
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy(blacklistedDomain, resource, caddyForwardProxyBlackListing.addr, httpTargetVer,
+			response, err := getViaProxy(blacklistedDomain, resource, caddyForwardProxyBlackListing.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -158,9 +158,9 @@ func TestBlacklistBlocking(t *testing.T) {
 		}
 	}
 
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy(blacklistedIPv4, resource, caddyForwardProxyBlackListing.addr, httpTargetVer,
+			response, err := getViaProxy(blacklistedIPv4, resource, caddyForwardProxyBlackListing.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -170,9 +170,9 @@ func TestBlacklistBlocking(t *testing.T) {
 		}
 	}
 
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy(blacklistedIPv6, resource, caddyForwardProxyBlackListing.addr, httpTargetVer,
+			response, err := getViaProxy("["+blacklistedIPv6+"]:80", resource, caddyForwardProxyBlackListing.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)
@@ -185,9 +185,9 @@ func TestBlacklistBlocking(t *testing.T) {
 
 func TestBlacklistAllowing(t *testing.T) {
 	useTls := true
-	for _, httpTargetVer := range testHttpVersions {
+	for _, httpProxyVer := range testHttpProxyVersions {
 		for _, resource := range testResources {
-			response, err := getViaProxy(caddyTestTarget.addr, resource, caddyForwardProxyBlackListing.addr, httpTargetVer,
+			response, err := getViaProxy(caddyTestTarget.addr, resource, caddyForwardProxyBlackListing.addr, httpProxyVer,
 				"", useTls)
 			if err != nil {
 				t.Fatal(err)

--- a/common_test.go
+++ b/common_test.go
@@ -36,7 +36,12 @@ Auth/NoAuth
 Empty/Correct/Wrong -- tries different credentials
 */
 var testResources = []string{"", "/pic.png"}
-var testHttpVersions = []string{"HTTP/2.0", "HTTP/1.1"}
+var testHttpProxyVersions = []string{"HTTP/2.0", "HTTP/1.1"}
+var testHttpTargetVersions = []string{"HTTP/1.1"}
+var httpVersionToAlpn = map[string]string{
+	"HTTP/1.1": "http/1.1",
+	"HTTP/2.0": "h2",
+}
 
 var blacklistedDomain = "google-public-dns-a.google.com" // supposed to ever resolve to one of 2 IP addresses below
 var blacklistedIPv4 = "8.8.8.8"

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -1,0 +1,228 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// httpclient is used by the upstreaming forwardproxy to establish connections to http(s) upstreams.
+// it implements x/net/proxy.Dialer interface
+package httpclient
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/http2"
+)
+
+// HTTPConnectDialer allows to configure one-time use HTTP CONNECT client
+type HTTPConnectDialer struct {
+	ProxyUrl      url.URL
+	DefaultHeader http.Header
+
+	// TODO: If spkiFp is set, use it as SPKI fingerprint to confirm identity of the
+	// proxy, instead of relying on standard PKI CA roots
+	SpkiFP []byte
+
+	Dialer net.Dialer // overridden dialer allow to control establishment of TCP connection
+
+	// overridden DialTLS allows user to control establishment of TLS connection,
+	// given TCP connection. returns established TLS connection, ALPN and error
+	DialTLS func(net.Conn) (net.Conn, string, error)
+}
+
+// NewHTTPClient creates a client to issue CONNECT requests and tunnel traffic via HTTPS proxy.
+// proxyUrlStr must provide Scheme and Host, may provide credentials and port.
+// Example: https://username:password@golang.org:443
+func NewHTTPConnectDialer(proxyUrlStr string) (*HTTPConnectDialer, error) {
+	proxyUrl, err := url.Parse(proxyUrlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	if proxyUrl.Host == "" {
+		return nil, errors.New("misparsed `url=`, make sure to specify full url like https://username:password@hostname.com:443/")
+	}
+
+	switch proxyUrl.Scheme {
+	case "http":
+		if proxyUrl.Port() == "" {
+			proxyUrl.Host = net.JoinHostPort(proxyUrl.Host, "80")
+		}
+	case "https":
+		if proxyUrl.Port() == "" {
+			proxyUrl.Host = net.JoinHostPort(proxyUrl.Host, "443")
+		}
+	case "":
+		return nil, errors.New("specify scheme explicitly (https://)")
+	default:
+		return nil, errors.New("scheme " + proxyUrl.Scheme + " is not supported")
+	}
+
+	client := &HTTPConnectDialer{
+		ProxyUrl:      *proxyUrl,
+		DefaultHeader: make(http.Header),
+		SpkiFP:        nil,
+	}
+
+	if proxyUrl.User != nil {
+		if proxyUrl.User.Username() != "" {
+			password, _ := proxyUrl.User.Password()
+			client.DefaultHeader.Set("Proxy-Authorization", "Basic "+
+				base64.StdEncoding.EncodeToString([]byte(proxyUrl.User.Username()+":"+password)))
+		}
+	}
+	return client, nil
+}
+
+func (c *HTTPConnectDialer) Dial(network, address string) (net.Conn, error) {
+	return c.DialContext(context.Background(), network, address)
+}
+
+// Users of context.WithValue should define their own types for keys
+type ContextKeyHeader struct{}
+
+// ctx.Value will be inspected for optional ContextKeyHeader{} key, with `http.Header` value,
+// which will be added to outgoing request headers, overriding any colliding c.DefaultHeader
+func (c *HTTPConnectDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	req := (&http.Request{
+		Method: "CONNECT",
+		URL:    &url.URL{Host: address},
+		Header: make(http.Header),
+		Host:   address,
+	}).WithContext(ctx)
+	for k, v := range c.DefaultHeader {
+		req.Header[k] = v
+	}
+	if ctxHeader, ctxHasHeader := ctx.Value(ContextKeyHeader{}).(http.Header); ctxHasHeader {
+		for k, v := range ctxHeader {
+			req.Header[k] = v
+		}
+	}
+
+	rawConn, err := c.Dialer.DialContext(ctx, network, c.ProxyUrl.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	negotiatedProtocol := ""
+	switch c.ProxyUrl.Scheme {
+	case "http":
+	case "https":
+		if c.DialTLS != nil {
+			rawConn, negotiatedProtocol, err = c.DialTLS(rawConn)
+			if err != nil {
+				return nil, err
+			}
+			break
+		}
+		tlsConf := tls.Config{
+			NextProtos: []string{"h2", "http/1.1"},
+			ServerName: c.ProxyUrl.Hostname(),
+		}
+
+		tlsConn := tls.Client(rawConn, &tlsConf)
+		err = tlsConn.Handshake()
+		if err != nil {
+			return nil, err
+		}
+		negotiatedProtocol = tlsConn.ConnectionState().NegotiatedProtocol
+		rawConn = tlsConn
+	default:
+		return nil, errors.New("scheme " + c.ProxyUrl.Scheme + " is not supported")
+	}
+
+	var proxyConn net.Conn
+
+	var resp *http.Response
+	switch negotiatedProtocol {
+	case "":
+		fallthrough
+	case "http/1.1":
+		req.Proto = "HTTP/1.1"
+		req.ProtoMajor = 1
+		req.ProtoMinor = 1
+
+		err = req.Write(rawConn)
+		if err != nil {
+			rawConn.Close()
+			return nil, err
+		}
+
+		resp, err = http.ReadResponse(bufio.NewReader(rawConn), req)
+		if err != nil {
+			rawConn.Close()
+			return nil, err
+		}
+
+		proxyConn = rawConn
+	case "h2":
+		req.Proto = "HTTP/2.0"
+		req.ProtoMajor = 2
+		req.ProtoMinor = 0
+		pr, pw := io.Pipe()
+		req.Body = ioutil.NopCloser(pr)
+
+		t := http2.Transport{}
+		h2client, err := t.NewClientConn(rawConn)
+		if err != nil {
+			rawConn.Close()
+			return nil, err
+		}
+
+		resp, err = h2client.RoundTrip(req)
+		if err != nil {
+			rawConn.Close()
+			return nil, err
+		}
+
+		proxyConn = &http2Conn{Conn: rawConn, in: pw, out: resp.Body}
+	default:
+		rawConn.Close()
+		return nil, errors.New("negotiated unsupported application layer protocol: " +
+			negotiatedProtocol)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		rawConn.Close()
+		return nil, errors.New("Proxy responded with non 200 code: " + resp.Status)
+	}
+
+	return proxyConn, nil
+}
+
+type http2Conn struct {
+	net.Conn
+	in  *io.PipeWriter
+	out io.ReadCloser
+}
+
+func (h *http2Conn) Read(p []byte) (n int, err error) {
+	return h.out.Read(p)
+}
+
+func (h *http2Conn) Write(p []byte) (n int, err error) {
+	return h.in.Write(p)
+}
+
+func (h *http2Conn) Close() error {
+	h.out.Close()
+	h.in.Close()
+	return h.Conn.Close()
+}

--- a/setup_test.go
+++ b/setup_test.go
@@ -122,6 +122,8 @@ func TestSetup(t *testing.T) {
 	testParsing([]string{"upstream https://proxy.site"}, true)
 	testParsing([]string{"upstream https://caddyserver.com", "acl {\nallow all\n}"}, false)
 	testParsing([]string{"upstream https://caddyserver.com", "ports 123"}, false)
+	testParsing([]string{"upstream https://username:password@caddyserver.com", "ports 123"}, false)
+	testParsing([]string{"upstream https://username:password@caddyserver.com:90", "ports 123"}, false)
 
 	testParsing([]string{"acl {\nallow all\n}"}, true)
 	testParsing([]string{"acl {\nallow localhost 128.32.22.1/32 1.1.1.1 caddyserver.com\n deny all\n}"}, true)


### PR DESCRIPTION
Turns out, we weren't actually testing http2. This commit fixes this
It's forked off #41, as it uses and tests some logic from httpclient.