### PR TITLE
Change DialTLS signature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
- - 1.9.x
+ - 1.10.x
 
 dist: trusty
 

--- a/common_test.go
+++ b/common_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 var credentialsEmpty = ""
+var credentialsCorrectPlain = "test:pass"
 var credentialsCorrect = "Basic dGVzdDpwYXNz"                                 // test:pass
 var credentialsUpstreamCorrect = "basic dXBzdHJlYW10ZXN0OnVwc3RyZWFtcGFzcw==" // upstreamtest:upstreampass
 var credentialsWrong = []string{
@@ -62,6 +63,7 @@ type caddyTestServer struct {
 var (
 	caddyForwardProxy            caddyTestServer
 	caddyForwardProxyAuth        caddyTestServer // requires auth
+	caddyHTTPForwardProxyAuth    caddyTestServer // requires auth, does not use TLS
 	caddyForwardProxyProbeResist caddyTestServer // requires auth, and has probing resistance on
 	caddyDummyProbeResist        caddyTestServer // same as caddyForwardProxyProbeResist, but w/o forwardproxy
 
@@ -140,6 +142,12 @@ func TestMain(m *testing.M) {
 			"acl {\nallow all\n}"}}
 	caddyForwardProxyAuth.StartTestServer()
 
+	caddyHTTPForwardProxyAuth = caddyTestServer{addr: "127.0.0.2:6973", root: "./test/forwardproxy",
+		directives:   []string{"tls off"},
+		proxyEnabled: true, proxyDirectives: []string{"basicauth test pass",
+			"acl {\nallow all\n}"}}
+	caddyHTTPForwardProxyAuth.StartTestServer()
+
 	caddyForwardProxyProbeResist = caddyTestServer{addr: "127.0.0.2:8888", root: "./test/forwardproxy",
 		directives: []string{"tls self_signed"}, HTTPRedirectPort: "8880",
 		proxyEnabled: true, proxyDirectives: []string{"basicauth test pass",
@@ -192,6 +200,7 @@ func TestMain(m *testing.M) {
 
 	caddyForwardProxy.Stop()
 	caddyForwardProxyAuth.Stop()
+	caddyHTTPForwardProxyAuth.Stop()
 	caddyForwardProxyProbeResist.Stop()
 	caddyDummyProbeResist.Stop()
 	caddyTestTarget.Stop()

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -1,0 +1,96 @@
+// tests ./httpclient/ but is in root as it needs access to test files in root
+package forwardproxy
+
+import (
+	"crypto/tls"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/forwardproxy/httpclient"
+)
+
+func TestHttpClient(t *testing.T) {
+	_test := func(proxyUrl string) {
+		for _, httpProxyVer := range testHttpProxyVersions {
+			for _, httpTargetVer := range testHttpTargetVersions {
+				for _, resource := range testResources {
+					dialer, err := httpclient.NewHTTPConnectDialer(proxyUrl)
+					if err != nil {
+						t.Fatal(err)
+					}
+					dialer.DialTLS = func(network string, address string) (net.Conn, string, error) {
+						conn, err := tls.Dial(network, address, &tls.Config{InsecureSkipVerify: true,
+							NextProtos: []string{httpVersionToAlpn[httpProxyVer]}})
+						if err != nil {
+							return nil, "", err
+						}
+						return conn, conn.ConnectionState().NegotiatedProtocol, nil
+					}
+					conn, err := dialer.Dial("tcp", caddyTestTarget.addr)
+					if err != nil {
+						t.Fatal(err)
+					}
+					response, err := getResourceViaProxyConn(conn, caddyTestTarget.addr, resource, httpTargetVer, credentialsCorrect)
+					if err != nil {
+						t.Fatal(httpProxyVer, httpTargetVer, err)
+					} else if err = responseExpected(response, caddyTestTarget.contents[resource]); err != nil {
+						t.Fatal(httpProxyVer, httpTargetVer, err)
+					}
+				}
+			}
+		}
+	}
+
+	_test("https://" + credentialsCorrectPlain + "@" + caddyForwardProxyAuth.addr)
+	_test("http://" + credentialsCorrectPlain + "@" + caddyHTTPForwardProxyAuth.addr)
+}
+
+func TestHttpClientH2Multiplexing(t *testing.T) {
+	// doesn't actually confirm that it is multiplexed, just that it doesn't break things
+	// but it was manually inspected in Wireshark when this code was committed
+	httpProxyVer := "HTTP/2.0"
+	httpTargetVer := "HTTP/1.1"
+
+	dialer, err := httpclient.NewHTTPConnectDialer("https://" + credentialsCorrectPlain + "@" + caddyForwardProxyAuth.addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dialer.DialTLS = func(network string, address string) (net.Conn, string, error) {
+		conn, err := tls.Dial(network, address, &tls.Config{InsecureSkipVerify: true,
+			NextProtos: []string{httpVersionToAlpn[httpProxyVer]}})
+		if err != nil {
+			return nil, "", err
+		}
+		return conn, conn.ConnectionState().NegotiatedProtocol, nil
+	}
+
+	retries := 20
+	sleepInterval := time.Millisecond * 100
+
+	var wg sync.WaitGroup
+	wg.Add(retries + 1) // + for one serial launch
+	_test := func() {
+		defer wg.Done()
+		for _, resource := range testResources {
+			conn, err := dialer.Dial("tcp", caddyTestTarget.addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response, err := getResourceViaProxyConn(conn, caddyTestTarget.addr, resource, httpTargetVer, credentialsCorrect)
+			if err != nil {
+				t.Fatal(httpProxyVer, httpTargetVer, err)
+			} else if err = responseExpected(response, caddyTestTarget.contents[resource]); err != nil {
+				t.Fatal(httpProxyVer, httpTargetVer, err)
+			}
+		}
+	}
+
+	_test() // do serially at least once
+
+	for i := 0; i < retries; i++ {
+		go _test()
+		time.Sleep(sleepInterval)
+	}
+}

--- a/setup.go
+++ b/setup.go
@@ -284,13 +284,12 @@ func setup(c *caddy.Controller) error {
 				// disabling verification helps with testing the package and setups
 				// either way, it's impossible to have a legit TLS certificate for "127.0.0.1"
 				log.Println("Localhost upstream detected, disabling verification of TLS certificate")
-				d.DialTLS = func(conn net.Conn) (net.Conn, string, error) {
-					cl := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
-					err := cl.Handshake()
+				d.DialTLS = func(network string, address string) (net.Conn, string, error) {
+					conn, err := tls.Dial(network, address, &tls.Config{InsecureSkipVerify: true})
 					if err != nil {
 						return nil, "", err
 					}
-					return cl, cl.ConnectionState().NegotiatedProtocol, err
+					return conn, conn.ConnectionState().NegotiatedProtocol, nil
 				}
 			}
 			return d, nil


### PR DESCRIPTION
### 1. What does this change do, exactly?
Make it be like standard Transport.DialTLS, because it's good to be
like standard things.
TLSConn interface allows usage of thrid party TLS stacks, enabling
https://github.com/refraction-networking/utls.Roller integration.

### 2. Please link to the relevant issues.
None

### 3. Which documentation changes (if any) need to be made because of this PR?
None are needed

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change -- _already existing regression tests work_
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code

@dalyk