### PR TITLE
Add http.Transport + performance improvements

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -106,9 +106,7 @@ func (fp *ForwardProxy) portIsAllowed(port string) bool {
 // Copies data target->clientReader and clientWriter->target, and flushes as needed
 // Returns when clientWriter-> target stream is done.
 // Caddy should finish writing target -> clientReader.
-func dualStream(target net.Conn, clientReader io.ReadCloser,
-	clientWriter io.Writer) error {
-
+func dualStream(target net.Conn, clientReader io.ReadCloser, clientWriter io.Writer) error {
 	stream := func(w io.Writer, r io.Reader) error {
 		// copy bytes from r to w
 		buf := bufferPool.Get().([]byte)

--- a/forwardproxy_test.go
+++ b/forwardproxy_test.go
@@ -137,7 +137,8 @@ func getResourceViaProxyConn(proxyConn net.Conn, targetHost, resource, httpTarge
 		if err != nil {
 			return nil, err
 		}
-		return clientConn.RoundTrip(&req)
+		r, e := clientConn.RoundTrip(&req)
+		return r, e
 	case "HTTP/1.1":
 		req.ProtoMajor = 1
 		req.ProtoMinor = 1

--- a/forwardproxy_test.go
+++ b/forwardproxy_test.go
@@ -137,8 +137,7 @@ func getResourceViaProxyConn(proxyConn net.Conn, targetHost, resource, httpTarge
 		if err != nil {
 			return nil, err
 		}
-		r, e := clientConn.RoundTrip(&req)
-		return r, e
+		return clientConn.RoundTrip(&req)
 	case "HTTP/1.1":
 		req.ProtoMajor = 1
 		req.ProtoMinor = 1

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -278,10 +278,14 @@ func (h *http2Conn) Close() error {
 	return h.out.Close()
 }
 
+func (h *http2Conn) CloseConn() error {
+	return h.Conn.Close()
+}
+
 func (h *http2Conn) CloseWrite() error {
-	return h.out.Close()
+	return h.in.Close()
 }
 
 func (h *http2Conn) CloseRead() error {
-	return h.in.Close()
+	return h.out.Close()
 }

--- a/setup.go
+++ b/setup.go
@@ -274,7 +274,11 @@ func setup(c *caddy.Controller) error {
 	}
 	fp.dialContext = dialer.DialContext
 	fp.httpTransport.DialContext = func(ctx context.Context, network string, address string) (net.Conn, error) {
-		return fp.dialContextCheckACL(ctx, network, address)
+		conn, err := fp.dialContextCheckACL(ctx, network, address)
+		if err != nil {
+			return conn, err
+		}
+		return conn, nil
 	}
 
 	if fp.upstream != nil {


### PR DESCRIPTION
### 1. What does this change do, exactly?
Adds http.Transport to handle GET requests for non-upstreaming proxies (implements #37).
Upstreaming proxies will use httpclient to establish persistent connection to upstream instead.
Fix the issue with hang connections in `dualStream` (fixes #33)
httpclient: unlock the client before doing RoundTrip (fixes #45, more precisely, the issue that @joeshae reported in the last comment) 

### 2. Please link to the relevant issues.
implements #37
fixes #33
fixes #45

### 3. Which documentation changes (if any) need to be made because of this PR?
Seems to be none.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
