### PR TITLE
Add realm to Proxy-Authenticate header

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -311,7 +311,7 @@ func (fp *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, 
 			httpserver.WriteSiteNotFound(w, r)
 			return 0, authErr // current Caddy behavior without forwardproxy
 		} else {
-			w.Header().Set("Proxy-Authenticate", "Basic")
+			w.Header().Set("Proxy-Authenticate", "Basic realm=\"Caddy Secure Web Proxy\"")
 			return http.StatusProxyAuthRequired, authErr
 		}
 	}


### PR DESCRIPTION
### 1. What does this change do, exactly?
Even though realm was not required in older standards, newer https://tools.ietf.org/html/rfc7617 says
```
The authentication parameter 'realm' is REQUIRED ([RFC7235], Section 2.2).
```

I can't seem to find any function meaning between realms in this context. Squid's default realm is "Squid proxy-caching web server", so I gave descriptive realm to Caddy as well: "Caddy Secure Web Proxy".

`Proxy-Authenticate: Basic` -> `Proxy-Authenticate: Basic realm="Caddy Secure Web Proxy"`


### 2. Please link to the relevant issues.

Resolves #52

### 3. Which documentation changes (if any) need to be made because of this PR?
None

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
   - Tests currently fail in master, but seemingly due to changes in Golang. Will have to fix tests first. 
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
