### PR TITLE
Add realm to Proxy-Authenticate with probe resist

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -212,7 +212,7 @@ func serveHiddenPage(w http.ResponseWriter, authErr error) (int, error) {
 
 	w.Header().Set("Content-Type", "text/html")
 	if authErr != nil {
-		w.Header().Set("Proxy-Authenticate", "Basic")
+		w.Header().Set("Proxy-Authenticate", "Basic realm=\"Caddy Secure Web Proxy\"")
 		w.WriteHeader(http.StatusProxyAuthRequired)
 		w.Write([]byte(fmt.Sprintf(hiddenPage, AuthFail)))
 		return 0, authErr


### PR DESCRIPTION
In #53 we added a realm to the Proxy-Authenticate header, but the realm
only is added, when `probe_resistance` is off.
Proxy-Authenticate header should have a realm when `probe_resistance` is
on as well.

### 1. What does this change do, exactly?
Add realm to Proxy-Authenticate header of Hidden Page,
which is served when `probe_resistance` is on.

### 2. Please link to the relevant issues.

#52

### 3. Which documentation changes (if any) need to be made because of this PR?

None

### 4. Checklist

- [x] I have written tests and verified that they pass
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
