### PR TITLE
Change caddy path to github.com/caddyserver/caddy

### DIFF
--- a/cmd/caddy/caddy.go
+++ b/cmd/caddy/caddy.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/mholt/caddy/caddy/caddymain"
+	"github.com/caddyserver/caddy/caddy/caddymain"
 
 	_ "github.com/caddyserver/forwardproxy"
 )

--- a/common_test.go
+++ b/common_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 var credentialsEmpty = ""
@@ -95,7 +95,7 @@ func (c *caddyTestServer) marshal() []byte {
 	mainBlock = append(mainBlock, "}")
 	if len(c.HTTPRedirectPort) > 0 {
 		// TODO: this is not good enough, since `func redirPlaintextHost(cfg *SiteConfig) *SiteConfig`
-		// https://github.com/mholt/caddy/blob/master/caddyhttp/httpserver/https.go#L142 can change in future
+		// https://github.com/caddyserver/caddy/blob/master/caddyhttp/httpserver/https.go#L142 can change in future
 		// and we won't know.
 		redirectBlock := []string{"http://*:" + c.HTTPRedirectPort + " {",
 			"redir https://" + c.addr + "{uri}",

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -34,8 +34,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"github.com/caddyserver/forwardproxy/httpclient"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
 type ForwardProxy struct {

--- a/forwardproxy_test.go
+++ b/forwardproxy_test.go
@@ -28,11 +28,11 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/caddyserver/caddy/caddyhttp/header"
+	_ "github.com/caddyserver/caddy/caddyhttp/httpserver"
+	_ "github.com/caddyserver/caddy/caddyhttp/redirect"
+	_ "github.com/caddyserver/caddy/caddyhttp/root"
 	"github.com/caddyserver/forwardproxy/httpclient"
-	_ "github.com/mholt/caddy/caddyhttp/header"
-	_ "github.com/mholt/caddy/caddyhttp/httpserver"
-	_ "github.com/mholt/caddy/caddyhttp/redirect"
-	_ "github.com/mholt/caddy/caddyhttp/root"
 	"golang.org/x/net/http2"
 )
 

--- a/setup.go
+++ b/setup.go
@@ -31,9 +31,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"github.com/caddyserver/forwardproxy/httpclient"
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
 	"golang.org/x/net/proxy"
 )
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -17,7 +17,7 @@ package forwardproxy
 import (
 	"testing"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func TestSetup(t *testing.T) {


### PR DESCRIPTION
### 1. What does this change do, exactly?
Changes caddy's import path from github.com/mholt/caddy to github.com/caddyserver/caddy

### 2. Please link to the relevant issues.
Closes #62

### 3. Which documentation changes (if any) need to be made because of this PR?
None
