### PR TITLE
Fix misuse of sync.Pool

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -111,6 +111,7 @@ func dualStream(target net.Conn, clientReader io.ReadCloser, clientWriter io.Wri
 		buf := bufferPool.Get().([]byte)
 		buf = buf[0:cap(buf)]
 		_, _err := flushingIoCopy(w, r, buf)
+		bufferPool.Put(buf)
 		if closeWriter, ok := w.(interface {
 			CloseWrite() error
 		}); ok {
@@ -468,6 +469,7 @@ func forwardResponse(w http.ResponseWriter, response *http.Response) error {
 	buf := bufferPool.Get().([]byte)
 	buf = buf[0:cap(buf)]
 	_, err := io.CopyBuffer(w, response.Body, buf)
+	bufferPool.Put(buf)
 	return err
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
The buffers got from bufferPool are never put back. They will still get GCed sometime later, but that's not the purpose of using sync.Pool

### 2. Please link to the relevant issues.
N/A

### 3. Which documentation changes (if any) need to be made because of this PR?
None.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
