### PR TITLE
Support Caddy2 caddyfile

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -46,7 +46,7 @@ type Handler struct {
 	// port     string // port on which chain with forwardproxy is listening on
 	Hosts caddyhttp.MatchHost `json:"hosts,omitempty"`
 
-	ProbeResistance *ProbeResistance
+	ProbeResistance *ProbeResistance `json:"probe_resistance"`
 
 	DialTimeout caddy.Duration `json:"dial_timeout,omitempty"` // for initial tcp connection
 

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -50,7 +50,7 @@ type Handler struct {
 	// port     string // port on which chain with forwardproxy is listening on
 	Hosts caddyhttp.MatchHost `json:"hosts,omitempty"`
 
-	ProbeResistance *ProbeResistance `json:"probe_resistance"`
+	ProbeResistance *ProbeResistance `json:"probe_resistance,omitempty"`
 
 	DialTimeout caddy.Duration `json:"dial_timeout,omitempty"` // for initial tcp connection
 
@@ -711,7 +711,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		subdirective := d.Val()
 		args := d.RemainingArgs()
 		switch subdirective {
-		case "basicauth":
+		case "basic_auth":
 			if len(args) != 2 {
 				return d.ArgErr()
 			}
@@ -783,8 +783,6 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				h.PACPath = "/proxy.pac"
 			}
 			log.Printf("Proxy Auto-Config will be served at %s\n", h.PACPath)
-		case "response_timeout":
-			return d.Err("response_timeout not supported yet.")
 		case "dial_timeout":
 			if len(args) != 1 {
 				return d.ArgErr()
@@ -819,7 +817,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				case "allow":
 					ruleSubjects = args[:]
 					aclAllow = true
-				case "allowfile":
+				case "allow_file":
 					if len(args) != 1 {
 						return d.Err("allowfile accepts a single filename argument")
 					}
@@ -830,7 +828,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					aclAllow = true
 				case "deny":
 					ruleSubjects = args[:]
-				case "denyfile":
+				case "deny_file":
 					if len(args) != 1 {
 						return d.Err("denyfile accepts a single filename argument")
 					}

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -15,12 +15,15 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/forwardproxy/httpclient"
 	"golang.org/x/net/proxy"
@@ -28,6 +31,7 @@ import (
 
 func init() {
 	caddy.RegisterModule(Handler{})
+	httpcaddyfile.RegisterHandlerDirective("forward_proxy", parseCaddyfile)
 }
 
 type ProbeResistance struct {
@@ -695,8 +699,184 @@ type dialContexter interface {
 	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }
 
+func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	if !d.Next() {
+		return d.ArgErr()
+	}
+	args := d.RemainingArgs()
+	if len(args) > 0 {
+		return d.ArgErr()
+	}
+	for nesting := d.Nesting(); d.NextBlock(nesting); {
+		subdirective := d.Val()
+		args := d.RemainingArgs()
+		switch subdirective {
+		case "basicauth":
+			if len(args) != 2 {
+				return d.ArgErr()
+			}
+			if len(args[0]) == 0 {
+				return d.Err("empty usernames are not allowed")
+			}
+			// TODO: Evaluate policy of allowing empty passwords.
+			if strings.Contains(args[0], ":") {
+				return d.Err("character ':' in usernames is not allowed")
+			}
+			// TODO: Support multiple basicauths.
+			if h.BasicauthUser != "" || h.BasicauthPass != "" {
+				return d.Err("Multi-user basicauth is not supported")
+			}
+			h.BasicauthUser = args[0]
+			h.BasicauthPass = args[1]
+		case "ports":
+			if len(args) == 0 {
+				return d.ArgErr()
+			}
+			if len(h.WhitelistedPorts) != 0 {
+				return d.Err("ports subdirective specified twice")
+			}
+			h.WhitelistedPorts = make([]int, len(args))
+			for i, p := range args {
+				intPort, err := strconv.Atoi(p)
+				if intPort <= 0 || intPort > 65535 || err != nil {
+					return d.Err("ports are expected to be space-separated" +
+						" and in 0-65535 range. Got: " + p)
+				}
+				h.WhitelistedPorts[i] = intPort
+			}
+		case "hide_ip":
+			if len(args) != 0 {
+				return d.ArgErr()
+			}
+			h.HideIP = true
+		case "hide_via":
+			if len(args) != 0 {
+				return d.ArgErr()
+			}
+			h.HideVia = true
+		case "probe_resistance":
+			if len(args) > 1 {
+				return d.ArgErr()
+			}
+			if len(args) == 1 {
+				lowercaseArg := strings.ToLower(args[0])
+				if lowercaseArg != args[0] {
+					log.Println("WARNING: secret domain appears to have uppercase letters in it, which are not visitable")
+				}
+				h.ProbeResistance = &ProbeResistance{Domain: args[0]}
+			} else {
+				h.ProbeResistance = &ProbeResistance{}
+			}
+		case "serve_pac":
+			if len(args) > 1 {
+				return d.ArgErr()
+			}
+			if len(h.PACPath) != 0 {
+				return d.Err("serve_pac subdirective specified twice")
+			}
+			if len(args) == 1 {
+				h.PACPath = args[0]
+				if !strings.HasPrefix(h.PACPath, "/") {
+					h.PACPath = "/" + h.PACPath
+				}
+			} else {
+				h.PACPath = "/proxy.pac"
+			}
+			log.Printf("Proxy Auto-Config will be served at %s\n", h.PACPath)
+		case "response_timeout":
+			return d.Err("response_timeout not supported yet.")
+		case "dial_timeout":
+			if len(args) != 1 {
+				return d.ArgErr()
+			}
+			timeout, err := caddy.ParseDuration(args[0])
+			if err != nil {
+				return d.ArgErr()
+			}
+			if timeout < 0 {
+				return d.Err("dial_timeout cannot be negative.")
+			}
+			h.DialTimeout = caddy.Duration(timeout)
+		case "upstream":
+			if len(args) != 1 {
+				return d.ArgErr()
+			}
+			if h.Upstream != "" {
+				return d.Err("upstream directive specified more than once")
+			}
+			h.Upstream = args[0]
+		case "acl":
+			for nesting := d.Nesting(); d.NextBlock(nesting); {
+				aclDirective := d.Val()
+				args := d.RemainingArgs()
+				if len(args) == 0 {
+					return d.ArgErr()
+				}
+				var ruleSubjects []string
+				var err error
+				aclAllow := false
+				switch aclDirective {
+				case "allow":
+					ruleSubjects = args[:]
+					aclAllow = true
+				case "allowfile":
+					if len(args) != 1 {
+						return d.Err("allowfile accepts a single filename argument")
+					}
+					ruleSubjects, err = readLinesFromFile(args[0])
+					if err != nil {
+						return err
+					}
+					aclAllow = true
+				case "deny":
+					ruleSubjects = args[:]
+				case "denyfile":
+					if len(args) != 1 {
+						return d.Err("denyfile accepts a single filename argument")
+					}
+					ruleSubjects, err = readLinesFromFile(args[0])
+					if err != nil {
+						return err
+					}
+				default:
+					return d.Err("expected acl directive: allow/allowfile/deny/denyfile." +
+						"got: " + aclDirective)
+				}
+				ar := ACLRule{Subjects: ruleSubjects, Allow: aclAllow}
+				h.ACL = append(h.ACL, ar)
+			}
+		default:
+			return d.ArgErr()
+		}
+	}
+	return nil
+}
+
+func readLinesFromFile(filename string) ([]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var hostnames []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		hostnames = append(hostnames, scanner.Text())
+	}
+
+	return hostnames, scanner.Err()
+}
+
+func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
+	var fp Handler
+	err := fp.UnmarshalCaddyfile(h.Dispenser)
+	return &fp, err
+}
+
 // Interface guards
 var (
 	_ caddy.Provisioner           = (*Handler)(nil)
 	_ caddyhttp.MiddlewareHandler = (*Handler)(nil)
+	_ caddyfile.Unmarshaler       = (*Handler)(nil)
 )

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -236,7 +236,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		return caddyhttp.Error(http.StatusProxyAuthRequired, authErr)
 	}
 
-	if r.ProtoMajor != 1 && r.ProtoMajor != 2 {
+	if r.ProtoMajor != 1 && r.ProtoMajor != 2 && r.ProtoMajor != 3 {
 		return caddyhttp.Error(http.StatusHTTPVersionNotSupported,
 			fmt.Errorf("unsupported HTTP major version: %d", r.ProtoMajor))
 	}
@@ -255,7 +255,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 
 	if r.Method == http.MethodConnect {
 
-		if r.ProtoMajor == 2 {
+		if r.ProtoMajor == 2 || r.ProtoMajor == 3 {
 			if len(r.URL.Scheme) > 0 || len(r.URL.Path) > 0 {
 				return caddyhttp.Error(http.StatusBadRequest,
 					fmt.Errorf("CONNECT request has :scheme and/or :path pseudo-header fields"))
@@ -282,6 +282,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		case 1: // http1: hijack the whole flow
 			return serveHijack(w, targetConn)
 		case 2: // http2: keep reading from "request" and writing into same response
+			fallthrough
+		case 3:
 			defer r.Body.Close()
 			wFlusher, ok := w.(http.Flusher)
 			if !ok {

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -236,7 +236,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		return caddyhttp.Error(http.StatusProxyAuthRequired, authErr)
 	}
 
-	if r.ProtoMajor != 1 && r.ProtoMajor != 2 && r.ProtoMajor != 3 {
+	if r.ProtoMajor != 1 && r.ProtoMajor != 2 {
 		return caddyhttp.Error(http.StatusHTTPVersionNotSupported,
 			fmt.Errorf("unsupported HTTP major version: %d", r.ProtoMajor))
 	}
@@ -255,7 +255,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 
 	if r.Method == http.MethodConnect {
 
-		if r.ProtoMajor == 2 || r.ProtoMajor == 3 {
+		if r.ProtoMajor == 2 {
 			if len(r.URL.Scheme) > 0 || len(r.URL.Path) > 0 {
 				return caddyhttp.Error(http.StatusBadRequest,
 					fmt.Errorf("CONNECT request has :scheme and/or :path pseudo-header fields"))
@@ -282,8 +282,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		case 1: // http1: hijack the whole flow
 			return serveHijack(w, targetConn)
 		case 2: // http2: keep reading from "request" and writing into same response
-			fallthrough
-		case 3:
 			defer r.Body.Close()
 			wFlusher, ok := w.(http.Flusher)
 			if !ok {


### PR DESCRIPTION
My users like to use Caddyfile very much so here I make it useable.

I couldn't make the test to work. The test would be copied from https://github.com/caddyserver/forwardproxy/blob/master/setup_test.go and changed to use NewTestDispenser but I always get `./forwardproxy_test.go:436:7: undefined: NewTestDispenser` in go test.