### PR TITLE
Support HTTP/3

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -261,7 +261,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		return caddyhttp.Error(http.StatusProxyAuthRequired, authErr)
 	}
 
-	if r.ProtoMajor != 1 && r.ProtoMajor != 2 {
+	if r.ProtoMajor != 1 && r.ProtoMajor != 2 && r.ProtoMajor != 3 {
 		return caddyhttp.Error(http.StatusHTTPVersionNotSupported,
 			fmt.Errorf("unsupported HTTP major version: %d", r.ProtoMajor))
 	}
@@ -279,7 +279,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	}
 
 	if r.Method == http.MethodConnect {
-		if r.ProtoMajor == 2 {
+		if r.ProtoMajor == 2 || r.ProtoMajor == 3 {
 			if len(r.URL.Scheme) > 0 || len(r.URL.Path) > 0 {
 				return caddyhttp.Error(http.StatusBadRequest,
 					fmt.Errorf("CONNECT request has :scheme and/or :path pseudo-header fields"))
@@ -306,6 +306,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		case 1: // http1: hijack the whole flow
 			return serveHijack(w, targetConn)
 		case 2: // http2: keep reading from "request" and writing into same response
+			fallthrough
+		case 3:
 			defer r.Body.Close()
 			wFlusher, ok := w.(http.Flusher)
 			if !ok {


### PR DESCRIPTION
Though the patch is small it's not easy to test it because the pieces for H/3 have yet to fall in place.

First build Caddy with this PR. Then Caddyfile:
```
{
  experimental_http3
}
:443, example.com
tls me@example.com
route {
  forward_proxy {
    basic_auth user pass
    hide_ip
    hide_via
    probe_resistance secret.com
  }
  file_server {
    root /var/www/html
  }
}
```

Then
```
google-chrome --enable-quic --quic-version=h3-29 --proxy-server=quic://example.com secret.com
```
which prompts for password. After that you should be able to open http://example.com. Caddy should print a message like this:

`2020/10/02 01:23:45.678 ERROR	http.log.error	Proxy-Authorization is required! Expected format: <type> <credentials>{"request": {"remote_addr": "1.2.3.4:5678", "proto": "HTTP/3", "method": "GET", "host": "secret.com", "uri": "/", "headers": {"Upgrade-Insecure-Requests": ["1"], "User-Agent": ["Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36"], "Accept": ["text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"], "Accept-Encoding": ["gzip, deflate"], "Accept-Language": ["en-US,en;q=0.9"]}, "tls": {"resumed": false, "version": 0, "cipher_suite": 0, "proto": "", "proto_mutual": false, "server_name": ""}}, "duration": 0.000106268}`

I have a patch with quic-go v.0.18.0 https://github.com/lucas-clemente/quic-go/commit/c81eeb8bb855eeba6df52660efd99be6d74e6c87 to enable the CONNECT method. But Chrome has disabled QUIC proxying for any https origins and I haven't found the right parameters to turn it back on for this test. But my other customized proxy tool based on Chrome stack does work with HTTP/3 CONNECT in Caddy. This should make sense because the test above already shows GET requests get proxied correctly.