### PR TITLE
Buffer http response instead of writing directly

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -590,7 +590,13 @@ func serveHijack(w http.ResponseWriter, targetConn net.Conn) error {
 	}
 	res.Header.Set("Server", "Caddy")
 
-	err = res.Write(clientConn)
+	buf := bufio.NewWriter(clientConn)
+	err = res.Write(buf)
+	if err != nil {
+		return caddyhttp.Error(http.StatusInternalServerError,
+			fmt.Errorf("failed to write response: %v", err))
+	}
+	err = buf.Flush()
 	if err != nil {
 		return caddyhttp.Error(http.StatusInternalServerError,
 			fmt.Errorf("failed to send response to client: %v", err))


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

Currently when handling HTTP 1.1 CONNECT method, multiple packets are sent just to write the HTTP response header. This PR changes that. (Verified through tcpdump.)

### 2. Please link to the relevant issues.

N/A

### 3. Which documentation changes (if any) need to be made because of this PR?

N/A

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
