### PR TITLE
Removed insecure upstreams check

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -170,10 +170,6 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 		}
 		h.upstream = upstreamURL
 
-		if !isLocalhost(h.upstream.Hostname()) && h.upstream.Scheme != "https" {
-			return errors.New("insecure schemes are only allowed to localhost upstreams")
-		}
-
 		registerHTTPDialer := func(u *url.URL, _ proxy.Dialer) (proxy.Dialer, error) {
 			// CONNECT request is proxied as-is, so we don't care about target url, but it could be
 			// useful in future to implement policies of choosing between multiple upstream servers.


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### Dockerfile
```dockerfile
FROM caddy:builder AS builder
RUN xcaddy build \
    --with github.com/caddyserver/forwardproxy=github.com/saiv46/forwardproxy@patch-1
FROM caddy:latest
COPY --from=builder /usr/bin/caddy /usr/bin/caddy
```

### 1. What does this change do, exactly?
Removes `insecure schemes are only allowed to localhost upstreams`, because it prevents using upstreams in Docker containers.

### 2. Please link to the relevant issues.
Resolves #116

### 3. Which documentation changes (if any) need to be made because of this PR?
```diff
- Supported schemes to remote host: https.
- Supported schemes to localhost: socks5, http, https (certificate check is ignored).
+ Supported schemes: socks5, http, https (certificate check is ignored for localhost).
```

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
