### PR TITLE
Hashed passwords in basic_auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ route {
 	forward_proxy {
 		basic_auth user1 0NtCL2JPJBgPPMmlPcJ
 		basic_auth user2 密码
+		basic_auth user3 d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1 SHA256 # Third arg to specify hash algo
 		ports     80 443
 		hide_ip
 		hide_via
@@ -114,6 +115,8 @@ route {
 
 - `basic_auth [user] [password]`  
   Sets basic HTTP auth credentials. This property may be repeated multiple times. Note that this is different from Caddy's built-in `basic_auth` directive. BE SURE TO CHECK THE NAME OF THE SITE THAT IS REQUESTING CREDENTIALS BEFORE YOU ENTER THEM.
+
+  It is also possible to provide auth credentials with an hashed password. For now, the password must be SHA-256 encoded, provided in hex string format.
 
   Default: no authentication required.
 - `probe_resistance [secretlink.tld]`  

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -24,11 +24,11 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 }
 
 // EncodeAuthCredentials base64-encode credentials
-func EncodeAuthCredentialsRaw(user, pass string) (result []byte) {
+func EncodeAuthCredentialsRaw(user, pass string) string {
 	raw := []byte(user + ":" + pass)
-	result = make([]byte, base64.StdEncoding.EncodedLen(len(raw)))
+	result := make([]byte, base64.StdEncoding.EncodedLen(len(raw)))
 	base64.StdEncoding.Encode(result, raw)
-	return
+	return string(result)
 }
 
 // UnmarshalCaddyfile unmarshals Caddyfile tokens into h.

--- a/forwardproxy_test.go
+++ b/forwardproxy_test.go
@@ -230,12 +230,44 @@ func TestGETAuthCorrect(t *testing.T) {
 	}
 }
 
+func TestGETAuthCorrectHash(t *testing.T) {
+	const useTLS = true
+	for _, httpProxyVer := range testHTTPProxyVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy(caddyHTTPTestTarget.addr, resource, caddyForwardProxyAuthHash.addr, httpProxyVer, credentialsCorrect, useTLS)
+			if err != nil {
+				t.Fatal(err)
+			} else if err = responseExpected(response, caddyHTTPTestTarget.contents[resource]); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
 func TestGETAuthWrong(t *testing.T) {
 	const useTLS = true
 	for _, wrongCreds := range credentialsWrong {
 		for _, httpProxyVer := range testHTTPProxyVersions {
 			for _, resource := range testResources {
 				response, err := getViaProxy(caddyHTTPTestTarget.addr, resource, caddyForwardProxyAuth.addr, httpProxyVer, wrongCreds, useTLS)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if response.StatusCode != http.StatusProxyAuthRequired {
+					t.Fatalf("Expected response: 407 StatusProxyAuthRequired, Got: %d %s\n",
+						response.StatusCode, response.Status)
+				}
+			}
+		}
+	}
+}
+
+func TestGETAuthWrongHash(t *testing.T) {
+	const useTLS = true
+	for _, wrongCreds := range credentialsWrong {
+		for _, httpProxyVer := range testHTTPProxyVersions {
+			for _, resource := range testResources {
+				response, err := getViaProxy(caddyHTTPTestTarget.addr, resource, caddyForwardProxyAuthHash.addr, httpProxyVer, wrongCreds, useTLS)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/forwardproxy_test.go
+++ b/forwardproxy_test.go
@@ -244,6 +244,20 @@ func TestGETAuthCorrectHash(t *testing.T) {
 	}
 }
 
+func TestGETAuthCorrectHashWithCache(t *testing.T) {
+	const useTLS = true
+	for _, httpProxyVer := range testHTTPProxyVersions {
+		for _, resource := range testResources {
+			response, err := getViaProxy(caddyHTTPTestTarget.addr, resource, caddyForwardProxyAuthHash.addr, httpProxyVer, credentialsCorrect, useTLS)
+			if err != nil {
+				t.Fatal(err)
+			} else if err = responseExpected(response, caddyHTTPTestTarget.contents[resource]); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
 func TestGETAuthWrong(t *testing.T) {
 	const useTLS = true
 	for _, wrongCreds := range credentialsWrong {

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -54,6 +54,8 @@ func TestHttpClient(t *testing.T) {
 
 	_test("https://"+credentialsCorrectPlain, caddyForwardProxyAuth.addr)
 	_test("http://"+credentialsCorrectPlain, caddyHTTPForwardProxyAuth.addr)
+
+	_test("https://"+credentialsCorrectPlain, caddyForwardProxyAuthHash.addr)
 }
 
 func TestHttpClientH2Multiplexing(t *testing.T) {


### PR DESCRIPTION
Hi all

### 1. What does this change do, exactly?

This PR introduces a mechanism to specify passwords as hashed strings, in `basic_auth`. The proposed implementation allows for hex-encoded, SHA-256 hashes; more algorithms can be plugged in easily and I'll be glad to do it if this PR is of interest. The current authentication schema is of course maintained, and the current configuration files are still accepted as they are.

The `basic_auth` node now has three values, with the third being the algorithm. `RAW` is plain text (current), and can be omitted. `SHA256` was added. An example of a valid caddyfile:

```caddyfile
:80
route {
  forward_proxy {
    basic_auth test1 pass1
    basic_auth test2 pass2 RAW
    # Password is "pass3" hashed
    basic_auth test3 3acb59306ef6e660cf832d1d34c4fba3d88d616f0bb5c2a9e0f82d18ef6fc167 SHA256
  }
}
```

There are no added libraries or dependencies. I tried to minimize the amount of code changes; this is my first contribution, and I may have departed from standards somewhere; please let me know (in particular if I should write more comments).

The proposed code hashes the provided password at every request. It would be quite easy to cache the password after the first valid authentication, to speed up subsequent requests. Let me know if this is of interest.

To test the changes "live", apply the patches, then put the config above in a file `caddyfile` and run

```bash
xcaddy run -- --config caddyfile
```

Then

```bash
curl -x http://test1:pass1@localhost:80 https://ifconfig.io
curl -x http://test2:pass2@localhost:80 https://ifconfig.io
curl -x http://test3:pass3@localhost:80 https://ifconfig.io
curl -x http://test3:abcde@localhost:80 https://ifconfig.io # This one fails
```

### 2. Please link to the relevant issues.

None I am aware of.

### 3. Which documentation changes (if any) need to be made because of this PR?

I have modified `README.md` in the sections about `basic_auth`.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
