### PR TITLE
POC for using the basic_auth provisions from caddy internals

### DIFF
--- a/caddyauth_imported/adapter.go
+++ b/caddyauth_imported/adapter.go
@@ -1,0 +1,137 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyauthimported
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/caddyauth"
+)
+
+// [POC] Code is the same as forwardproxy's basicauth former implementation
+func getCredsFromHeader(r *http.Request) (string, string, error) {
+	pa := strings.Split(r.Header.Get("Proxy-Authorization"), " ")
+	if len(pa) != 2 {
+		return "", "", errors.New("Proxy-Authorization is required! Expected format: <type> <credentials>")
+	}
+	if strings.ToLower(pa[0]) != "basic" {
+		return "", "", errors.New("auth type is not supported")
+	}
+	buf := make([]byte, base64.StdEncoding.DecodedLen(len(pa[1])))
+	_, _ = base64.StdEncoding.Decode(buf, []byte(pa[1])) // should not err ever since we are decoding a known good input // TODO true?
+	credarr := strings.Split(string(buf), ":")
+
+	return credarr[0], credarr[1], nil
+}
+
+// Authenticate validates the user credentials in req and returns the user, if valid.
+// [POC] Same code as caddy's basicAuth, but it doesn't write anything on the ResponseWriter
+// Needs upstreaming, in case, to keep the code inside caddy.
+func (hba HTTPBasicAuth) AuthenticateNoCredsPrompt(req *http.Request) (caddyauth.User, bool, error) {
+	username, plaintextPasswordStr, err := getCredsFromHeader(req)
+	if err != nil {
+		return caddyauth.User{}, false, err
+	}
+
+	account, accountExists := hba.Accounts[username]
+	if !accountExists {
+		// don't return early if account does not exist; we want
+		// to try to avoid side-channels that leak existence, so
+		// we use a fake password to simulate realistic CPU cycles
+		account.password = hba.fakePassword
+	}
+
+	same, err := hba.correctPassword(account, []byte(plaintextPasswordStr))
+	if err != nil || !same || !accountExists {
+		return caddyauth.User{ID: username}, false, err
+	}
+
+	return caddyauth.User{ID: username}, true, nil
+}
+
+// [POC] Lifted/adapted from modules/caddyhttp/caddyauth/caddyfile.go#parseCaddyfile()
+// IDK how to reuse that method directly, honestly. Also, I don't have a httpcaddyfile.Helper as
+// in the original code, but a caddyfile.Dispenser seems to work.
+func ParseCaddyfileForHTTPBasicAuth(h *caddyfile.Dispenser) (*HTTPBasicAuth, error) {
+	// [POC] removed code
+	// h.Next() // consume directive name
+
+	// // "basicauth" is deprecated, replaced by "basic_auth"
+	// if h.Val() == "basicauth" {
+	// 	caddy.Log().Named("config.adapter.caddyfile").Warn("the 'basicauth' directive is deprecated, please use 'basic_auth' instead!")
+	// }
+
+	var ba HTTPBasicAuth
+	ba.HashCache = new(Cache)
+
+	var cmp caddyauth.Comparer
+	args := h.RemainingArgs()
+
+	var hashName string
+	switch len(args) {
+	case 0:
+		hashName = "bcrypt"
+	case 1:
+		hashName = args[0]
+	case 2:
+		hashName = args[0]
+		ba.Realm = args[1]
+	default:
+		return nil, h.ArgErr()
+	}
+
+	switch hashName {
+	case "bcrypt":
+		cmp = caddyauth.BcryptHash{}
+	default:
+		return nil, h.Errf("unrecognized hash algorithm: %s", hashName)
+	}
+
+	ba.HashRaw = caddyconfig.JSONModuleObject(cmp, "algorithm", hashName, nil)
+
+	for h.NextBlock(0) {
+		username := h.Val()
+
+		var b64Pwd string
+		h.Args(&b64Pwd)
+		if h.NextArg() {
+			return nil, h.ArgErr()
+		}
+
+		if username == "" || b64Pwd == "" {
+			return nil, h.Err("username and password cannot be empty or missing")
+		}
+
+		ba.AccountList = append(ba.AccountList, Account{
+			Username: username,
+			Password: b64Pwd,
+		})
+	}
+
+	// [POC] Removed code
+	// return Authentication{
+	// 	ProvidersRaw: caddy.ModuleMap{
+	// 		"http_basic": caddyconfig.JSON(ba, nil),
+	// 	},
+	// }, nil
+
+	// [POC] Added code
+	return &ba, nil
+}

--- a/caddyauth_imported/basicauth.go
+++ b/caddyauth_imported/basicauth.go
@@ -1,0 +1,312 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyauthimported
+
+// [POC] I had to duplicate this because it doesn't export 'password' (same as 'Password?),
+// fakePassword, correctPassword(). Upstream patch would be needed I am afraid.
+// Code is the same but for package references (caddyauth.User, caddyauth.Authenticator)
+// and I had to comment out init() because it would register the module again.
+// A source of confusion: xcaddy compiles against a later version than go test, and
+// between the two versions the Comparer interface changed. I cannot find how to align the
+// two methods of running this.
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	weakrand "math/rand"
+	"net/http"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/caddyauth"
+)
+
+// [POC] Removed code
+// func init() {
+// 	caddy.RegisterModule(HTTPBasicAuth{})
+// }
+
+// HTTPBasicAuth facilitates HTTP basic authentication.
+type HTTPBasicAuth struct {
+	// The algorithm with which the passwords are hashed. Default: bcrypt
+	HashRaw json.RawMessage `json:"hash,omitempty" caddy:"namespace=http.authentication.hashes inline_key=algorithm"`
+
+	// The list of accounts to authenticate.
+	AccountList []Account `json:"accounts,omitempty"`
+
+	// The name of the realm. Default: restricted
+	Realm string `json:"realm,omitempty"`
+
+	// If non-nil, a mapping of plaintext passwords to their
+	// hashes will be cached in memory (with random eviction).
+	// This can greatly improve the performance of traffic-heavy
+	// servers that use secure password hashing algorithms, with
+	// the downside that plaintext passwords will be stored in
+	// memory for a longer time (this should not be a problem
+	// as long as your machine is not compromised, at which point
+	// all bets are off, since basicauth necessitates plaintext
+	// passwords being received over the wire anyway). Note that
+	// a cache hit does not mean it is a valid password.
+	HashCache *Cache `json:"hash_cache,omitempty"`
+
+	Accounts map[string]Account `json:"-"`
+	Hash     Comparer           `json:"-"`
+
+	// fakePassword is used when a given user is not found,
+	// so that timing side-channels can be mitigated: it gives
+	// us something to hash and compare even if the user does
+	// not exist, which should have similar timing as a user
+	// account that does exist.
+	fakePassword []byte
+}
+
+// CaddyModule returns the Caddy module information.
+func (HTTPBasicAuth) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.authentication.providers.http_basic",
+		New: func() caddy.Module { return new(HTTPBasicAuth) },
+	}
+}
+
+// Provision provisions the HTTP basic auth provider.
+func (hba *HTTPBasicAuth) Provision(ctx caddy.Context) error {
+	if hba.HashRaw == nil {
+		hba.HashRaw = json.RawMessage(`{"algorithm": "bcrypt"}`)
+	}
+
+	// load password hasher
+	hasherIface, err := ctx.LoadModule(hba, "HashRaw")
+	if err != nil {
+		return fmt.Errorf("loading password hasher module: %v", err)
+	}
+	hba.Hash = hasherIface.(Comparer)
+
+	if hba.Hash == nil {
+		return fmt.Errorf("hash is required")
+	}
+
+	// if supported, generate a fake password we can compare against if needed
+	if hasher, ok := hba.Hash.(Hasher); ok {
+		hba.fakePassword = hasher.FakeHash()
+	}
+
+	repl := caddy.NewReplacer()
+
+	// load account list
+	hba.Accounts = make(map[string]Account)
+	for i, acct := range hba.AccountList {
+		if _, ok := hba.Accounts[acct.Username]; ok {
+			return fmt.Errorf("account %d: username is not unique: %s", i, acct.Username)
+		}
+
+		acct.Username = repl.ReplaceAll(acct.Username, "")
+		acct.Password = repl.ReplaceAll(acct.Password, "")
+
+		if acct.Username == "" || acct.Password == "" {
+			return fmt.Errorf("account %d: username and password are required", i)
+		}
+
+		// TODO: Remove support for redundantly-encoded b64-encoded hashes
+		// Passwords starting with '$' are likely in Modular Crypt Format,
+		// so we don't need to base64 decode them. But historically, we
+		// required redundant base64, so we try to decode it otherwise.
+		if strings.HasPrefix(acct.Password, "$") {
+			acct.password = []byte(acct.Password)
+		} else {
+			acct.password, err = base64.StdEncoding.DecodeString(acct.Password)
+			if err != nil {
+				return fmt.Errorf("base64-decoding password: %v", err)
+			}
+		}
+
+		hba.Accounts[acct.Username] = acct
+	}
+	hba.AccountList = nil // allow GC to deallocate
+
+	if hba.HashCache != nil {
+		hba.HashCache.cache = make(map[string]bool)
+		hba.HashCache.mu = new(sync.RWMutex)
+		hba.HashCache.g = new(singleflight.Group)
+	}
+
+	return nil
+}
+
+// Authenticate validates the user credentials in req and returns the user, if valid.
+func (hba HTTPBasicAuth) Authenticate(w http.ResponseWriter, req *http.Request) (caddyauth.User, bool, error) {
+	username, plaintextPasswordStr, ok := req.BasicAuth()
+	if !ok {
+		return hba.promptForCredentials(w, nil)
+	}
+
+	account, accountExists := hba.Accounts[username]
+	if !accountExists {
+		// don't return early if account does not exist; we want
+		// to try to avoid side-channels that leak existence, so
+		// we use a fake password to simulate realistic CPU cycles
+		account.password = hba.fakePassword
+	}
+
+	same, err := hba.correctPassword(account, []byte(plaintextPasswordStr))
+	if err != nil || !same || !accountExists {
+		return hba.promptForCredentials(w, err)
+	}
+
+	return caddyauth.User{ID: username}, true, nil
+}
+
+func (hba HTTPBasicAuth) correctPassword(account Account, plaintextPassword []byte) (bool, error) {
+	compare := func() (bool, error) {
+		return hba.Hash.Compare(account.password, plaintextPassword)
+	}
+
+	// if no caching is enabled, simply return the result of hashing + comparing
+	if hba.HashCache == nil {
+		return compare()
+	}
+
+	// compute a cache key that is unique for these input parameters
+	cacheKey := hex.EncodeToString(append(account.password, plaintextPassword...))
+
+	// fast track: if the result of the input is already cached, use it
+	hba.HashCache.mu.RLock()
+	same, ok := hba.HashCache.cache[cacheKey]
+	hba.HashCache.mu.RUnlock()
+	if ok {
+		return same, nil
+	}
+	// slow track: do the expensive op, then add it to the cache
+	// but perform it in a singleflight group so that multiple
+	// parallel requests using the same password don't cause a
+	// thundering herd problem by all performing the same hashing
+	// operation before the first one finishes and caches it.
+	v, err, _ := hba.HashCache.g.Do(cacheKey, func() (any, error) {
+		return compare()
+	})
+	if err != nil {
+		return false, err
+	}
+	same = v.(bool)
+	hba.HashCache.mu.Lock()
+	if len(hba.HashCache.cache) >= 1000 {
+		hba.HashCache.makeRoom() // keep cache size under control
+	}
+	hba.HashCache.cache[cacheKey] = same
+	hba.HashCache.mu.Unlock()
+
+	return same, nil
+}
+
+func (hba HTTPBasicAuth) promptForCredentials(w http.ResponseWriter, err error) (caddyauth.User, bool, error) {
+	// browsers show a message that says something like:
+	// "The website says: <realm>"
+	// which is kinda dumb, but whatever.
+	realm := hba.Realm
+	if realm == "" {
+		realm = "restricted"
+	}
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s"`, realm))
+	return caddyauth.User{}, false, err
+}
+
+// Cache enables caching of basic auth results. This is especially
+// helpful for secure password hashes which can be expensive to
+// compute on every HTTP request.
+type Cache struct {
+	mu *sync.RWMutex
+	g  *singleflight.Group
+
+	// map of concatenated hashed password + plaintext password, to result
+	cache map[string]bool
+}
+
+// makeRoom deletes about 1/10 of the items in the cache
+// in order to keep its size under control. It must not be
+// called without a lock on c.mu.
+func (c *Cache) makeRoom() {
+	// we delete more than just 1 entry so that we don't have
+	// to do this on every request; assuming the capacity of
+	// the cache is on a long tail, we can save a lot of CPU
+	// time by doing a whole bunch of deletions now and then
+	// we won't have to do them again for a while
+	numToDelete := len(c.cache) / 10
+	if numToDelete < 1 {
+		numToDelete = 1
+	}
+	for deleted := 0; deleted <= numToDelete; deleted++ {
+		// Go maps are "nondeterministic" not actually random,
+		// so although we could just chop off the "front" of the
+		// map with less code, this is a heavily skewed eviction
+		// strategy; generating random numbers is cheap and
+		// ensures a much better distribution.
+		//nolint:gosec
+		rnd := weakrand.Intn(len(c.cache))
+		i := 0
+		for key := range c.cache {
+			if i == rnd {
+				delete(c.cache, key)
+				break
+			}
+			i++
+		}
+	}
+}
+
+// Comparer is a type that can securely compare
+// a plaintext password with a hashed password
+// in constant-time. Comparers should hash the
+// plaintext password and then use constant-time
+// comparison.
+type Comparer interface {
+	// Compare returns true if the result of hashing
+	// plaintextPassword is hashedPassword, false
+	// otherwise. An error is returned only if
+	// there is a technical/configuration error.
+	Compare(hashedPassword, plaintextPassword []byte) (bool, error)
+}
+
+// Hasher is a type that can generate a secure hash
+// given a plaintext. Hashing modules which implement
+// this interface can be used with the hash-password
+// subcommand as well as benefitting from anti-timing
+// features. A hasher also returns a fake hash which
+// can be used for timing side-channel mitigation.
+type Hasher interface {
+	Hash(plaintext []byte) ([]byte, error)
+	FakeHash() []byte
+}
+
+// Account contains a username and password.
+type Account struct {
+	// A user's username.
+	Username string `json:"username"`
+
+	// The user's hashed password, in Modular Crypt Format (with `$` prefix)
+	// or base64-encoded.
+	Password string `json:"password"`
+
+	password []byte
+}
+
+// Interface guards
+var (
+	_ caddy.Provisioner       = (*HTTPBasicAuth)(nil)
+	_ caddyauth.Authenticator = (*HTTPBasicAuth)(nil)
+)

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -10,6 +10,7 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	caddyauthimported "github.com/proofrock/forwardproxy/caddyauth_imported"
 )
 
 func init() {
@@ -44,20 +45,11 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		args := d.RemainingArgs()
 		switch subdirective {
 		case "basic_auth":
-			if len(args) != 2 {
-				return d.ArgErr()
+			bam, err := caddyauthimported.ParseCaddyfileForHTTPBasicAuth(d)
+			if err != nil {
+				return err
 			}
-			if len(args[0]) == 0 {
-				return d.Err("empty usernames are not allowed")
-			}
-			// TODO: Evaluate policy of allowing empty passwords.
-			if strings.Contains(args[0], ":") {
-				return d.Err("character ':' in usernames is not allowed")
-			}
-			if h.AuthCredentials == nil {
-				h.AuthCredentials = [][]byte{}
-			}
-			h.AuthCredentials = append(h.AuthCredentials, EncodeAuthCredentials(args[0], args[1]))
+			h.BasicAuthModule = *bam
 		case "hosts":
 			if len(args) == 0 {
 				return d.ArgErr()


### PR DESCRIPTION
### 1. What does this change do, exactly?

Hello!
    as suggested, I tried to modify the `forwardproxy` current authentication to re-use caddy's (main) code. I think I am getting there, but there are a few things that - if you are interested - may need discussion.

I put comments on the relevant parts with a `[POC]` comment tag to identify them.

Some explanations:

- I tried to reuse `Authenticate` and `parseCaddyFile` to do the authentication and parsing, but they do just a little bit too much - the logic is adherent to where they're originally used (of course). For instance, `Authenticate` writes to the `ResponseWriter` and I don't think we need that; and `parseCaddyFile` is internal, uses a `httpcaddyfile.Helper` that is not available, and expects a slightly different "position" in the config file layout.
- So I duplicated the code in the `adapter.go` file, and marked with `[POC]` the code I removed. The code is still the same.
- Unfortunately, this meant duplicating also the file `basicauth.go` (as it is, save for the `init()` which shouldn't be repeated, and some imports) because it contains some internal fields and methods I need to access from those new methods.
- All this could be avoided and made transparent by minimally patching caddy's code, but for now I just wanted your opinion on all the setup.
- Code that use all this - in `caddyfile.go` and `forwardproxy.go` - should be quite straightforward; the changes in "protocol" - let's say - are also marked with `[POC]`
- Tests don't work 🤔 While `xcaddy run...` compiles against the latest caddy and my code is done against that version, `go test` compiles against v2.7.6, and there's a breaking change in `basicauth.go#Comparer` that makes things difficult. 
- Even after that, in the tests the auth object is provisioned manually, and the code would need a `ctx` I don't have available at initialization time. I tried to work around this, but the point before makes it really difficult; so I hope that it's possible to update the "base" version before (possibly, eventually) finalizing all this.

To test:

- Create a `caddyfile`

```
:80
route {
  forward_proxy {
    basic_auth
      test1 $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG
      test2 $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG
  }
}
```

- Run with `xcaddy run -- --config caddyfile`

- Try with
```bash
curl -x http://test1:hiccup@localhost:80 https://ifconfig.io # Success
curl -x http://test2:hiccup@localhost:80 https://ifconfig.io # Success
curl -x http://test3:hiccup@localhost:80 https://ifconfig.io # This one fails
curl -x http://test1:hiccap@localhost:80 https://ifconfig.io # This one fails
```

Thanks for the great code and the fun ride! Even if this will go nowhere, which is of course ok, I definitely learned something.

### 2. Please link to the relevant issues.

None

### 3. Which documentation changes (if any) need to be made because of this PR?

`README.md`, breaking changes should be explained in the `basic_auth` section(s).

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
