### PR TITLE
Implement `disable_insecure_upstreams_check`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ forward_proxy {
 	ports     80 443
 	hide_ip
 	hide_via
+	disable_insecure_upstreams_check
 	probe_resistance secret-link-kWWL9Q.com # alternatively you can use a real domain, such as caddyserver.com
 	serve_pac /secret-proxy.pac
 
@@ -133,6 +134,10 @@ forward_proxy {
   Only this address will trigger a 407 response, prompting browsers to request credentials from user and cache them for the rest of the session.
 
   Default: no probing resistance.
+- `disable_insecure_upstreams_check`  
+  Disables the check for insecure (HTTP) upstreams. By default, forwardproxy will refuse to connect to upstreams that are not using TLS. This option disables that check.
+
+  Default: check for insecure upstreams.
 
 ### Privacy
 

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -99,6 +99,13 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			h.HideVia = true
 
+		case "disable_insecure_upstreams_check":
+			args := d.RemainingArgs()
+			if len(args) != 0 {
+				return d.ArgErr()
+			}
+			h.DisableInsecureUpstreamsCheck = true
+
 		case "probe_resistance":
 			args := d.RemainingArgs()
 			if len(args) > 1 {

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -64,6 +64,9 @@ type Handler struct {
 	// If true, the Via header will not be added.
 	HideVia bool `json:"hide_via,omitempty"`
 
+	// If true, the strict check preventing HTTP upstreams will be disabled.
+	DisableInsecureUpstreamsCheck bool `json:"disable_insecure_upstreams_check,omitempty"`
+
 	// Host(s) (and ports) of the proxy. When you configure a client,
 	// you will give it the host (and port) of the proxy to use.
 	Hosts caddyhttp.MatchHost `json:"hosts,omitempty"`
@@ -191,7 +194,7 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 		}
 		h.upstream = upstreamURL
 
-		if !isLocalhost(h.upstream.Hostname()) && h.upstream.Scheme != "https" {
+		if !h.DisableInsecureUpstreamsCheck && !isLocalhost(h.upstream.Hostname()) && h.upstream.Scheme != "https" {
 			return errors.New("insecure schemes are only allowed to localhost upstreams")
 		}
 


### PR DESCRIPTION
Supersedes https://github.com/caddyserver/forwardproxy/pull/142, closes #116

In certain environments, making HTTP requests is necessary. We should allow users to drop this check if they understand what they're doing.