### PR TITLE
Fix error when using upstream for HTTP request

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -245,9 +245,9 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	// start by splitting the request host and port
-	reqHost, _, err := net.SplitHostPort(r.Host)
-	if err != nil {
-		reqHost = r.Host // OK; probably just didn't have a port
+	reqHost := r.Host
+	if h, _, err := net.SplitHostPort(r.Host); err == nil {
+		reqHost = h
 	}
 
 	var authErr error
@@ -360,7 +360,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		r.Header.Add("Via", strconv.Itoa(r.ProtoMajor)+"."+strconv.Itoa(r.ProtoMinor)+" caddy")
 	}
 
-	var response *http.Response
+	var (
+		response *http.Response
+		err      error
+	)
 	if h.upstream == nil {
 		// non-upstream request uses httpTransport to reuse connections
 		if r.Body != nil &&


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

This change properly scopes an error value.

Without scoping the error, any request with a `Host` header value that doesn't have a port will result in a bad gateway response _when the handler is configured with an upstream_.

This is because the error is shadowed [at this point during execution](https://github.com/caddyserver/forwardproxy/blob/0aab84dad4fc2830789f34e27b4d7bc22a40889e/forwardproxy.go#L394).

Here's an example route configuration that would error out:

```yml
- handler: forward_proxy
  upstream: http://my.proxy.com
```

Here's a command that would induce an error:

```bash
# assumes server listens on localhost 20000
curl -vv -x http://127.0.0.1:20000 http://ifconfig.io
```

### 2. Please link to the relevant issues.

N/A

### 3. Which documentation changes (if any) need to be made because of this PR?

N/A

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
