### PR TITLE
feat: add resolve subdirective for custom address resolution

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -184,6 +184,13 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			h.Upstream = args[0]
 
+		case "resolve":
+			args := d.RemainingArgs()
+			if len(args) != 2 {
+				return d.Err("resolve expects exactly two arguments: <from_host:port> <to_addr:port>")
+			}
+			h.Resolve = append(h.Resolve, ResolveEntry{From: args[0], To: args[1]})
+
 		case "acl":
 			for nesting := d.Nesting(); d.NextBlock(nesting); {
 				aclDirective := d.Val()

--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -90,6 +90,13 @@ type Handler struct {
 	// Optionally configure an upstream proxy to use.
 	Upstream string `json:"upstream,omitempty"`
 
+	// Custom address resolution entries. Each entry maps a host:port pattern
+	// to a dial address, similar to curl's --resolve flag. Patterns support
+	// wildcard prefixes (e.g., *.example.com:443). When the proxy needs to
+	// dial a target matching a pattern, it connects to the specified address
+	// instead, without DNS resolution of the original hostname.
+	Resolve []ResolveEntry `json:"resolve,omitempty"`
+
 	// Access control list.
 	ACL []ACLRule `json:"acl,omitempty"`
 
@@ -106,6 +113,40 @@ type Handler struct {
 
 	// TODO: temporary/deprecated - we should try to reuse existing authentication modules instead!
 	AuthCredentials [][]byte `json:"auth_credentials,omitempty"` // slice with base64-encoded credentials
+}
+
+// ResolveEntry maps a host:port pattern to a dial address.
+// The pattern may use a wildcard prefix (e.g., *.example.com:443).
+type ResolveEntry struct {
+	// The host:port pattern to match (e.g., "example.com:443", "*.local:443").
+	From string `json:"from"`
+	// The address:port to dial instead (e.g., "127.0.0.1:443").
+	To string `json:"to"`
+}
+
+// resolveAddress checks if hostPort matches any resolve entry and returns
+// the mapped address if found, or the original hostPort if not.
+func (h Handler) resolveAddress(hostPort string) string {
+	for _, entry := range h.Resolve {
+		if matchHostPort(entry.From, hostPort) {
+			return entry.To
+		}
+	}
+	return hostPort
+}
+
+// matchHostPort matches a hostPort against a pattern that may contain
+// a wildcard prefix (e.g., *.example.com:443 matches sub.example.com:443).
+func matchHostPort(pattern, hostPort string) bool {
+	if pattern == hostPort {
+		return true
+	}
+	if !strings.HasPrefix(pattern, "*.") {
+		return false
+	}
+	// Wildcard: *.example.com:443 matches anything.example.com:443
+	suffix := pattern[1:] // ".example.com:443"
+	return strings.HasSuffix(hostPort, suffix)
 }
 
 // CaddyModule returns the Caddy module information.
@@ -184,6 +225,10 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 	}
 	h.dialContext = dialer.DialContext
 	h.httpTransport.DialContext = func(ctx context.Context, network string, address string) (net.Conn, error) {
+		resolved := h.resolveAddress(address)
+		if resolved != address {
+			return h.dialContext(ctx, network, resolved)
+		}
 		return h.dialContextCheckACL(ctx, network, address)
 	}
 
@@ -304,7 +349,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		if hostPort == "" {
 			hostPort = r.Host
 		}
-		targetConn, err := h.dialContextCheckACL(ctx, "tcp", hostPort)
+
+		// Resolve configured address mappings. When resolve matches,
+		// bypass ACL — the target is explicitly configured, not user-controlled.
+		dialAddr := h.resolveAddress(hostPort)
+		var targetConn net.Conn
+		var err error
+		if dialAddr != hostPort {
+			targetConn, err = h.dialContext(ctx, "tcp", dialAddr)
+		} else {
+			targetConn, err = h.dialContextCheckACL(ctx, "tcp", hostPort)
+		}
 		if err != nil {
 			return err
 		}

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -1,0 +1,70 @@
+package forwardproxy
+
+import "testing"
+
+func TestMatchHostPort(t *testing.T) {
+	tests := []struct {
+		pattern  string
+		hostPort string
+		want     bool
+	}{
+		// Exact match
+		{"example.com:443", "example.com:443", true},
+		{"example.com:443", "other.com:443", false},
+		{"example.com:443", "example.com:80", false},
+
+		// Wildcard match
+		{"*.example.com:443", "sub.example.com:443", true},
+		{"*.example.com:443", "deep.sub.example.com:443", true},
+		{"*.example.com:443", "example.com:443", false},
+		{"*.example.com:443", "sub.example.com:80", false},
+		{"*.example.com:443", "sub.other.com:443", false},
+
+		// Wildcard with different ports
+		{"*.something.test:443", "test.something.test:443", true},
+		{"*.something.test:443", "fleet.something.test:443", true},
+		{"*.something.test:443", "test.something.test:80", false},
+
+		// No wildcard, no match
+		{"example.com:443", "sub.example.com:443", false},
+	}
+
+	for _, tt := range tests {
+		got := matchHostPort(tt.pattern, tt.hostPort)
+		if got != tt.want {
+			t.Errorf("matchHostPort(%q, %q) = %v, want %v", tt.pattern, tt.hostPort, got, tt.want)
+		}
+	}
+}
+
+func TestResolveAddress(t *testing.T) {
+	h := Handler{
+		Resolve: []ResolveEntry{
+			{From: "*.something.test:443", To: "127.0.0.1:443"},
+			{From: "specific.host:8080", To: "10.0.0.1:8080"},
+		},
+	}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Wildcard match
+		{"test.something.test:443", "127.0.0.1:443"},
+		{"fleet.something.test:443", "127.0.0.1:443"},
+
+		// Exact match
+		{"specific.host:8080", "10.0.0.1:8080"},
+
+		// No match — returned as-is
+		{"other.com:443", "other.com:443"},
+		{"test.something.test:80", "test.something.test:80"},
+	}
+
+	for _, tt := range tests {
+		got := h.resolveAddress(tt.input)
+		if got != tt.want {
+			t.Errorf("resolveAddress(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
### 1. What does this change do, exactly?

Add a resolve subdirective that allows mapping hostnames to specific addresses before dialing. Supports wildcard patterns and automatically allows localhost targets in the ACL. Bypasses ACL checks only for resolved addresses, not globally.

### 2. Please link to the relevant issues.

https://github.com/caddyserver/forwardproxy/issues/105

### 3. Which documentation changes (if any) need to be made because of this PR?

the forward_proxy block has a new directive similar to `curl --resolve`
forward_proxy {
   resolve *.something.local:443 127.0.0.1:443
}

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
