### PR TITLE
Handle dial failures for allowed IPs by returning Bad Gateway response

### DIFF
--- a/forwardproxy.go
+++ b/forwardproxy.go
@@ -533,15 +533,32 @@ match:
 
 	// This is net.Dial's default behavior: if the host resolves to multiple IP addresses,
 	// Dial will try each IP address in order until one succeeds
+
+	var lastDialErr error
+	var hadAllowedIP bool
+
 	for _, ip := range IPs {
 		if !h.hostIsAllowed(host, ip) {
 			continue
 		}
 
+		hadAllowedIP = true
+
 		conn, err = h.dialContext(ctx, network, net.JoinHostPort(ip.String(), port))
 		if err == nil {
 			return conn, nil
 		}
+
+		lastDialErr = err
+	}
+
+	// If at least one IP address was permitted by ACL but dialing all of them failed,
+	// return Bad Gateway. Otherwise the host did not have any allowed IPs and is forbidden.
+	if hadAllowedIP {
+		return nil, caddyhttp.Error(
+			http.StatusBadGateway,
+			fmt.Errorf("failed to connect to %s after trying allowed IP addresses: %v", host, lastDialErr),
+		)
 	}
 
 	return nil, caddyhttp.Error(http.StatusForbidden, fmt.Errorf("no allowed IP addresses for %s", host))

--- a/forwardproxy_test.go
+++ b/forwardproxy_test.go
@@ -216,6 +216,19 @@ func TestGETNoAuth(t *testing.T) {
 	}
 }
 
+func TestGETAllowedIPDialFailureReturnsBadGateway(t *testing.T) {
+	const useTLS = true
+	for _, httpProxyVer := range testHTTPProxyVersions {
+		response, err := getViaProxy("198.51.100.1:12345", "/", caddyForwardProxy.addr, httpProxyVer, credentialsEmpty, useTLS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if response.StatusCode != http.StatusBadGateway {
+			t.Fatalf("Expected response 502 StatusBadGateway for allowed host with dial failure, got %d", response.StatusCode)
+		}
+	}
+}
+
 func TestGETAuthCorrect(t *testing.T) {
 	const useTLS = true
 	for _, httpProxyVer := range testHTTPProxyVersions {


### PR DESCRIPTION
### 1. What does this change do, exactly?

This change fixes the HTTP status returned when a host resolves to at least one IP address allowed by the ACL, but dialing all allowed IPs fails.

Previously, the forward proxy returned `403 Forbidden` in this situation, even though the host itself was permitted by the ACL and the actual failure occurred during connection establishment.

The issue can be reproduced even with a configuration that explicitly allows all IPs:

```caddyfile
{
	debug
	admin off
}

:3128 {
	log
	forward_proxy {
		acl {
			allow all
		}
	}
}
```

Example:

```console
$ curl --silent --show-error --dump-header - -x http://localhost:3128 http://todo.stbu.net
HTTP/1.1 403 Forbidden
Server: Caddy
Date: Sat, 16 May 2026 08:46:00 GMT
Content-Length: 0

$ curl --silent --show-error --dump-header - http://todo.stbu.net
curl: (7) Failed to connect to todo.stbu.net port 80: Connection refused
```

This also resulted in misleading debug log output such as:

```log
2026/05/16 08:39:01.698 DEBUG   http.log.error  no allowed IP addresses for todo.stbu.net       {"request": {"remote_ip": "127.0.0.1", "remote_port": "42688", "client_ip": "127.0.0.1", "proto": "HTTP/1.1", "method": "GET", "host": "todo.stbu.net", "uri": "http://todo.stbu.net/", "headers": {"User-Agent": ["curl/7.76.1"], "Accept": ["*/*"], "Proxy-Connection": ["Keep-Alive"]}}, "duration": 0.001023666, "status": 403, "err_id": "gdy36zp6g", "err_trace": "forwardproxy.Handler.dialContextCheckACL (forwardproxy.go:547)"}
```

even though allowed IPs were present and connection attempts had actually been made.

With this change:

* `403 Forbidden` is returned only when no resolved IP addresses are allowed by the ACL
* `502 Bad Gateway` is returned when at least one allowed IP was attempted but all connection attempts failed

A regression test was added to verify the corrected behaviour.

### 2. Please link to the relevant issues.

N/A

### 3. Which documentation changes (if any) need to be made because of this PR?

None.

### 4. Checklist

* [x] I have written tests and verified that they fail without my change
* [x] I made pull request as minimal and simple as possible. If change is not small or additional dependencies are required, I opened an issue to propose and discuss the design first
* [x] I have squashed any insignificant commits
* [x] This change has comments for package types, values, functions, and non-obvious lines of code

### 5. AI disclosure

I discovered and narrowed down this issue in my production environment. After analysing the source code, I suspected that the problem originated exactly in the area modified by this change.

I then used ChatGPT to review and validate that assumption. After confirming the likely cause, I implemented the fix myself. GitHub Copilot was subsequently used for minor code refinement, and the regression test case was initially generated with Copilot assistance.


